### PR TITLE
Check include folders and expose to configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "hemtt"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "armake2 0.3.0 (git+https://github.com/KoffeinFlummi/armake2)",

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -77,6 +77,5 @@ It is recommended you add the following to your `.gitignore` if you are putting 
 ```
 *.pbo
 *.biprivatekey
-keys/
 releases/
 ```

--- a/docs/json.md
+++ b/docs/json.md
@@ -84,6 +84,19 @@ HEMTT will copy the files to the release directory after a successful release bu
 ```
 <hr/>
 
+## include
+**Type**: Array \[String (Path)\]
+
+HEMTT will include matching relative or absolute paths when building.
+
+```json
+"include": [
+    "./include"
+]
+```
+
+`./include` will be automatically added on project creation if "include" folder is present.
+
 ## exclude
 **Type**: Array \[String\]
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use crate::error;
+use crate::error::*;
 
 pub fn modtime(addon: String) -> Result<SystemTime, std::io::Error> {
     let mut recent: SystemTime = SystemTime::now() - Duration::new(60 * 60 * 24 * 365 * 10, 0);
@@ -50,8 +51,8 @@ pub fn build(p: &crate::project::Project) -> Result<(), std::io::Error> {
             &mut outf,
             &vec![],
             &p.exclude,
-            &vec![PathBuf::from("./include"), PathBuf::from(".")],
-        )?;
+            &p.include,
+        ).print_error(false);
     }
     Ok(())
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -96,7 +96,7 @@ fn _build(p: &crate::project::Project, source: &Path, target: &Path, name: &str)
     let mut outf = File::create(target)?;
 
     let mut include = p.include.to_owned();
-    include.push(PathBuf::form("."));
+    include.push(PathBuf::from("."));
 
     armake2::pbo::cmd_build(
         source.to_path_buf(),

--- a/src/project.rs
+++ b/src/project.rs
@@ -4,7 +4,7 @@ use serde_json;
 use std::fs::File;
 use std::io::BufReader;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::io::prelude::*;
 use std::io::Write;
 
@@ -17,8 +17,19 @@ pub struct Project {
     #[serde(default = "get_version_unwrap")]
     pub version: Option<String>,
     pub files: Vec<String>,
+    #[serde(default = "default_include")]
+    pub include: Vec<PathBuf>,
     #[serde(default = "default_exclude")]
     pub exclude: Vec<String>,
+}
+
+fn default_include() -> Vec<PathBuf> {
+    let mut includes: Vec<PathBuf> = vec![PathBuf::from(".")];
+    if PathBuf::from("./include").exists() {
+        includes.push(PathBuf::from("./include"));
+    }
+
+    includes
 }
 
 fn default_exclude() -> Vec<String> {
@@ -39,6 +50,7 @@ pub fn init(name: String, prefix: String, author: String) -> Result<Project, std
         prefix: prefix,
         author: author,
         files: vec!["mod.cpp".to_owned()],
+        include: vec![],
         exclude: vec![],
         version: None,
     };

--- a/src/project.rs
+++ b/src/project.rs
@@ -24,7 +24,8 @@ pub struct Project {
 }
 
 fn default_include() -> Vec<PathBuf> {
-    let mut includes: Vec<PathBuf> = vec![PathBuf::from(".")];
+    let mut includes = vec![];
+
     if PathBuf::from("./include").exists() {
         includes.push(PathBuf::from("./include"));
     }


### PR DESCRIPTION
**When merged this pull request will:**
- Fix building when `./include` folder does not exist (eg. no CBA includes or different name)
- Expose include folders to `hemtt.json`
- Print pretty errors from armake2 and gracefully handle them
- Move `keys` from root to `releases/keys`
  - Shall be made configurable one day