### PR TITLE
Add configurable header extensions, signature name and mod name

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -154,3 +154,13 @@ HEMTT will use the specified signature name as part of the full signature (`.bis
 ### Replacements
 
 - `{{version}}`: Mod version in format `MAJOR.MINOR.PATCH.BUILD`
+
+### Example
+
+```json
+"project": "TST",
+"version": "1.0.0.0",
+"signame": "my-{{version}}"
+```
+
+Above will result in signature name of `TST_<addon>.pbo.my-1.0.0.0.bisign` (where `<addon>` is the name of the addon folder), located next to the matching addon PBO.

--- a/docs/json.md
+++ b/docs/json.md
@@ -154,6 +154,28 @@ HEMTT will use the specified mod name (without `@`) to form `@mod` folder.
 "modname": "my_mod"
 ```
 
+## keyname
+**Type**: String
+
+HEMTT will use the specified key name for `.bikey` and `.biprivatekey` names.
+
+```json
+"keyname": "my_key"
+```
+### Replacements
+
+- `{{version}}`: Mod version in format `MAJOR.MINOR.PATCH.BUILD`
+
+### Example
+
+```json
+"project": "TST",
+"version": "1.0.0.0",
+"keyname": "my_key-{{version}}"
+```
+
+Above will result in key name of `my_key-1.0.0.0.bikey` and private key name of `my_key-1.0.0.0.biprivatekey`.
+
 ## signame
 **Type**: String
 

--- a/docs/json.md
+++ b/docs/json.md
@@ -121,3 +121,36 @@ HEMMT will build the specified optionals from the `./optionals` folder.
     "particles"
 ]
 ```
+
+## headerexts
+**Type**: Array \[String\]
+
+HEMTT will apply specified header extensions to each PBO.
+
+```json
+"headerexts": [
+    "author=me"
+]
+```
+
+## modname
+**Type**: String
+
+HEMTT will use the specified mod name (without `@`) to form `@mod` folder.
+
+```json
+"modname": "my_mod"
+```
+
+## signame
+**Type**: String
+
+HEMTT will use the specified signature name as part of the full signature (`.bisign`) name.
+
+```json
+"signame": "my_custom_name"
+```
+
+### Replacements
+
+- `{{version}}`: Mod version in format `MAJOR.MINOR.PATCH.BUILD`

--- a/src/build.rs
+++ b/src/build.rs
@@ -42,20 +42,26 @@ pub fn build(p: &crate::project::Project) -> Result<(), Error> {
 }
 
 pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Error> {
+    // Build
     println!(" {} release v{}", "Preparing".green().bold(), version);
     if Path::new(&format!("releases/{}", version)).exists() {
         return Err(error!("Release already exists, run with --force to clean"));
     }
     build(&p)?;
-    if !Path::new(&format!("releases/{}/@{}/addons", version, p.prefix)).exists() {
-        fs::create_dir_all(format!("releases/{}/@{}/addons", version, p.prefix))?;
+
+
+    let modname = p.get_modname();
+    if !Path::new(&format!("releases/{}/@{}/addons", version, modname)).exists() {
+        fs::create_dir_all(format!("releases/{}/@{}/addons", version, modname))?;
     }
-    if !Path::new(&format!("releases/{}/@{}/keys", version, p.prefix)).exists() {
-        fs::create_dir_all(format!("releases/{}/@{}/keys", version, p.prefix))?;
+    if !Path::new(&format!("releases/{}/@{}/keys", version, modname)).exists() {
+        fs::create_dir_all(format!("releases/{}/@{}/keys", version, modname))?;
     }
     for file in &p.files {
-        fs::copy(file, format!("releases/{}/@{}/{}", version, p.prefix, file))?;
+        fs::copy(file, format!("releases/{}/@{}/{}", version, modname, file))?;
     }
+
+    // Generate key
     if !Path::new("releases/keys").exists() {
         fs::create_dir("releases/keys")?;
     }
@@ -65,16 +71,22 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
         fs::rename(format!("{}.bikey", p.prefix), format!("releases/keys/{}.bikey", p.prefix))?;
         fs::rename(format!("{}.biprivatekey", p.prefix), format!("releases/keys/{}.biprivatekey", p.prefix))?;
     }
-    fs::copy(format!("releases/keys/{}.bikey", p.prefix), format!("releases/{0}/@{1}/keys/{1}.bikey", version, p.prefix))?;
-    for entry in fs::read_dir("addons").unwrap() {
-        _copy_sign(&entry.unwrap(), &p, &version)?;
+
+    // Sign
+    fs::copy(format!("releases/keys/{}.bikey", p.prefix), format!("releases/{0}/@{1}/keys/{2}.bikey", version, modname, p.prefix))?;
+
+    let mut folder = String::from("addons");
+    for entry in fs::read_dir(&folder).unwrap() {
+        _copy_sign(&folder, &entry.unwrap(), &p, &version)?;
     }
-    if Path::new("optionals").exists() {
-        if !Path::new(&format!("releases/{}/@{}/optionals", version, p.prefix)).exists() {
-            fs::create_dir_all(format!("releases/{}/@{}/optionals", version, p.prefix))?;
+
+    folder = String::from("optionals");
+    if Path::new(&folder).exists() {
+        if !Path::new(&format!("releases/{}/@{}/{}", version, modname, folder)).exists() {
+            fs::create_dir_all(format!("releases/{}/@{}/{}", version, modname, folder))?;
         }
-        for entry in fs::read_dir("optionals").unwrap() {
-            _copy_sign(&entry.unwrap(), &p, &version)?;
+        for entry in fs::read_dir(&folder).unwrap() {
+            _copy_sign(&folder, &entry.unwrap(), &p, &version)?;
         }
     }
     Ok(())
@@ -99,29 +111,35 @@ fn _build(p: &crate::project::Project, source: &Path, target: &Path, name: &str)
     include.push(PathBuf::from("."));
 
     armake2::pbo::cmd_build(
-        source.to_path_buf(),
-        &mut outf,
-        &vec![],
-        &p.exclude,
-        &include,
+        source.to_path_buf(),   // Source
+        &mut outf,              // Target
+        &p.get_headerexts(),    // Header extensions
+        &p.exclude,             // Exclude files glob patterns
+        &include,               // Include folders
     ).print_error(false);
     Ok(true)
 }
 
-fn _copy_sign(entry: &DirEntry, p: &crate::project::Project, version: &String) -> Result<bool, Error> {
+fn _copy_sign(folder: &String, entry: &DirEntry, p: &crate::project::Project, version: &String) -> Result<bool, Error> {
     let path = entry.path();
     let cpath = path.clone();
     let cpath = cpath.to_str().unwrap().replace(r#"\"#,"/");
-    if !path.ends_with(".pbo") && !cpath.contains(p.prefix.as_str()) {
+    let pbo = cpath.replace((folder.clone() + "/").as_str(), "");
+    if !path.ends_with(".pbo") && !pbo.contains(p.prefix.as_str()) {
         return Ok(false);
     }
-    fs::copy(&cpath, format!("releases/{}/@{}/{}", version, p.prefix, cpath))?;
-    println!("   {} {}", "Signing".green().bold(), cpath);
+
+    let modname = p.get_modname();
+    fs::copy(&cpath, format!("releases/{}/@{}/{}/{}", version, modname, folder, pbo))?;
+
+    let signame = p.get_signame(&pbo);
+
+    println!("   {0} {1}/{2} => {1}/{3}", "Signing".green().bold(), folder, pbo, signame);
     armake2::sign::cmd_sign(
         PathBuf::from(format!("releases/keys/{}.biprivatekey", p.prefix)),
-        PathBuf::from(format!("releases/{}/@{}/{}", version, p.prefix, cpath)),
-        Some(PathBuf::from(format!("releases/{0}/@{1}/{2}.{0}.bisign", version, p.prefix, cpath))),
+        PathBuf::from(format!("releases/{}/@{}/{}/{}", version, modname, folder, pbo)),
+        Some(PathBuf::from(format!("releases/{0}/@{1}/{2}/{3}", version, modname, folder, signame))),
         armake2::sign::BISignVersion::V3
-    )?;
+    ).print_error(false);
     Ok(true)
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -134,7 +134,7 @@ fn _copy_sign(folder: &String, entry: &DirEntry, p: &crate::project::Project, ve
 
     let signame = p.get_signame(&pbo);
 
-    println!("   {0} {1}/{2} => {1}/{3}", "Signing".green().bold(), folder, pbo, signame);
+    println!("   {} {}/{}", "Signing".green().bold(), folder, pbo);
     armake2::sign::cmd_sign(
         PathBuf::from(format!("releases/keys/{}.biprivatekey", p.prefix)),
         PathBuf::from(format!("releases/{}/@{}/{}/{}", version, modname, folder, pbo)),

--- a/src/build.rs
+++ b/src/build.rs
@@ -85,15 +85,19 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
 
     // Sign
     fs::copy(format!("releases/keys/{}.bikey", p.prefix), format!("releases/{0}/@{1}/keys/{2}.bikey", version, modname, p.prefix))?;
-    let dirs: Vec<_> = fs::read_dir("addons").unwrap()
+
+    let mut folder = String::from("addons");
+    let dirs: Vec<_> = fs::read_dir(&folder).unwrap()
         .map(|file| file.unwrap())
         .collect();
     dirs.par_iter().for_each(|entry| {
-        _copy_sign(&entry, &p, &version).unwrap();
+        _copy_sign(&folder, &entry, &p, &version).unwrap();
     });
-    if Path::new("optionals").exists() {
-        if !Path::new(&format!("releases/{}/@{}/optionals", version, p.prefix)).exists() {
-            fs::create_dir_all(format!("releases/{}/@{}/optionals", version, p.prefix))?;
+
+    folder = String::from("optionals");
+    if Path::new(&folder).exists() {
+        if !Path::new(&format!("releases/{}/@{}/{}", version, modname, folder)).exists() {
+            fs::create_dir_all(format!("releases/{}/@{}/{}", version, modname, folder))?;
         }
         for entry in fs::read_dir(&folder).unwrap() {
             _copy_sign(&folder, &entry.unwrap(), &p, &version)?;

--- a/src/files.rs
+++ b/src/files.rs
@@ -30,7 +30,7 @@ pub fn clear_pbos(p: &project::Project) -> Result<(), std::io::Error> {
 
 pub fn clear_release(version: &String) -> Result<(), Error> {
     if Path::new(&format!("releases/{}", version)).exists() {
-        println!("  {} release v{}", "Cleaning".yellow().bold(), version);
+        println!("  {} old release v{}", "Cleaning".yellow().bold(), version);
         fs::remove_dir_all(format!("releases/{}", version))?;
     }
     Ok(())

--- a/src/project.rs
+++ b/src/project.rs
@@ -31,6 +31,8 @@ pub struct Project {
     #[serde(default = "String::new")]
     pub modname: String,
     #[serde(default = "String::new")]
+    pub keyname: String,
+    #[serde(default = "String::new")]
     pub signame: String,
 }
 
@@ -53,6 +55,18 @@ impl Project {
 
     pub fn get_modname(&self) -> &String {
         if self.modname.is_empty() { &self.prefix } else { &self.modname }
+    }
+
+    pub fn get_keyname(&self) -> String {
+        if self.keyname.is_empty() {
+            self.prefix.clone()
+        } else {
+            let mut keyname = self.keyname.clone();
+            // TODO Use handlebars or at least common single function (???)
+            keyname = keyname.replace("{{version}}", &self.version.clone().unwrap());
+            keyname = keyname.replace("{{git_hash}}", "TODO"); // TODO Implement git hash look-up
+            keyname
+        }
     }
 
     pub fn get_signame(&self, pbo: &String) -> String {
@@ -90,6 +104,7 @@ pub fn init(name: String, prefix: String, author: String) -> Result<Project, Err
         skip: vec![],
         headerexts: vec![],
         modname: String::new(),
+        keyname: String::new(),
         signame: String::new(),
     };
     p.save()?;


### PR DESCRIPTION
**When merged this pull request will:**
- Work on #17 
- Add configurable header extensions
- Add configurable signature name (the middle part between PBO name and ".bisign")
- Add configurable mod name (`@mod` folder name)
- Add configurable key name (`.bikey` and `.biprivatekey` names)
- Add initial replacement patterns for header extensions and signature name properties (will be expanded in the future either with custom handling or [handlebars](https://github.com/sunng87/handlebars-rust) - thus the syntax)
- Change signing to print pretty errors from armake2 instead of panic on failure

Git hash parser can be added in separate PR as utility, otherwise this will get too big. Zip utility will also need it for parsing zip name.