### PR TITLE
Don't write private key to disk

### DIFF
--- a/docs/project.md
+++ b/docs/project.md
@@ -168,6 +168,8 @@ HEMTT will use the specified mod name (without `@`) to form `@mod` folder. Suppo
 
 HEMTT will use the specified key name for `.bikey` and `.biprivatekey` names. Supports [templating](/templating.md).
 
+The default is `{{prefix}}_{{version}}`, unless `reuse_private_key` is `true`, in which case the default is set to `{{prefix}}`
+
 ```json
 "keyname": "my_key"
 ```
@@ -177,10 +179,11 @@ HEMTT will use the specified key name for `.bikey` and `.biprivatekey` names. Su
 ```json
 "project": "TST",
 "version": "1.0.0.0",
-"keyname": "my_key-{{version}}"
+"keyname": "my_key_{{version}}"
 ```
 
-Above will result in key name of `my_key-1.0.0.0.bikey` and private key name of `my_key-1.0.0.0.biprivatekey`.
+Above will result in key name of `my_key_1.0.0.0.bikey` and private key name of `my_key_1.0.0.0.biprivatekey`.
+
 
 ## signame
 **Type**: String
@@ -200,3 +203,16 @@ HEMTT will use the specified signature name as part of the full signature (`.bis
 ```
 
 Above will result in signature name of `TST_<addon>.pbo.my-1.0.0.0.bisign` (where `<addon>` is the name of the addon folder), located next to the matching addon PBO.
+
+
+## reuse_private_key
+
+**Type**: bool
+
+If set to `true`, HEMTT will use (and re-use) `releases/keys/{keyname}.biprivatekey`. It will be generated if it doesn't exist.
+
+The default behaviour is to generate a new private key each time and discard it immediately; HEMTT strongly recommends that you only re-use the key if you are making a client-side mod where it will not matter if clients are running different versions of the mod.
+
+```json
+"reuse_private_key": false
+```

--- a/docs/project.md
+++ b/docs/project.md
@@ -168,7 +168,12 @@ HEMTT will use the specified mod name (without `@`) to form `@mod` folder. Suppo
 
 HEMTT will use the specified key name for `.bikey` and `.biprivatekey` names. Supports [templating](/templating.md).
 
-The default is `{{prefix}}_{{version}}`, unless `reuse_private_key` is `true`, in which case the default is set to `{{prefix}}`
+The default is set according to the following table:
+
+| `reuse_private_key` value | Default `keyname`         |
+| ------------------------- | ------------------------- |
+| `false`                   | `{{prefix}}_{{version}}`  |
+| `true`                    | `{{prefix}}`              |
 
 ```json
 "keyname": "my_key"
@@ -211,7 +216,9 @@ Above will result in signature name of `TST_<addon>.pbo.my-1.0.0.0.bisign` (wher
 
 If set to `true`, HEMTT will use (and re-use) `releases/keys/{keyname}.biprivatekey`. It will be generated if it doesn't exist.
 
-The default behaviour is to generate a new private key each time and discard it immediately; HEMTT strongly recommends that you only re-use the key if you are making a client-side mod where it will not matter if clients are running different versions of the mod.
+The default behaviour is to generate a new private key each time and discard it immediately.
+
+!> HEMTT strongly recommends that you only re-use the key if you are making a client-side mod where it will not matter if clients are running different versions of the mod.
 
 ```json
 "reuse_private_key": false

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,12 @@
+max_width = 125
+hard_tabs = false
+newline_style = "Unix"
+use_small_heuristics = "Default"
+reorder_imports = true
+reorder_modules = true
+remove_nested_parens = true
+edition = "2018"
+merge_derives = true
+use_try_shorthand = true
+use_field_init_shorthand = true
+force_explicit_abi = true

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -9,7 +9,7 @@ use rayon::prelude::*;
 
 use std::fs;
 use std::fs::File;
-use std::io::{Error};
+use std::io::Error;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, Instant};

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -9,8 +9,8 @@ use std::io::Error;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use crate::error::*;
 use crate::build::sign;
+use crate::error::*;
 
 pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Error> {
     let modname = p.get_modname();
@@ -37,17 +37,13 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
     let keyname = p.get_keyname();
     // Generate and store key if required
     if p.reuse_private_key {
-
         // Make a new keypair if there isn't one already
         if !Path::new(&format!("releases/keys/{}.bikey", keyname)).exists() {
             println!("    {} {}.bikey", "KeyGen".green().bold(), keyname);
 
             // Generate and write the keypair to disk in the current directory
             cmd_keygen(PathBuf::from(&keyname))?;
-            fs::rename(
-                format!("{}.bikey", keyname),
-                format!("releases/keys/{}.bikey", keyname),
-            )?;
+            fs::rename(format!("{}.bikey", keyname), format!("releases/keys/{}.bikey", keyname))?;
             fs::rename(
                 format!("{}.biprivatekey", keyname),
                 format!("releases/keys/{}.biprivatekey", keyname),
@@ -56,8 +52,7 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
 
         // Read the private key from disk
         key = BIPrivateKey::read(
-            &mut File::open(format!("releases/keys/{}.biprivatekey", keyname))
-                .expect("Failed to open private key"),
+            &mut File::open(format!("releases/keys/{}.biprivatekey", keyname)).expect("Failed to open private key"),
         )
         .expect("Failed to read private key");
     } else {
@@ -66,9 +61,7 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
         let public_key = key.to_public_key();
 
         // Write the public key to disk
-        public_key.write(
-            &mut std::fs::File::create(format!("releases/keys/{}.bikey", keyname)).unwrap_or_print(),
-        )?;
+        public_key.write(&mut std::fs::File::create(format!("releases/keys/{}.bikey", keyname)).unwrap_or_print())?;
     }
 
     // Copy public key to specific release dir
@@ -94,9 +87,7 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
 
     folder = String::from("optionals");
     if Path::new(&folder).exists() {
-        let addonsfolder = iformat!(
-            "releases/{version}/@{modname}/{folder}", version, modname, folder
-        );
+        let addonsfolder = iformat!("releases/{version}/@{modname}/{folder}", version, modname, folder);
         if !Path::new(&addonsfolder).exists() {
             fs::create_dir_all(addonsfolder)?;
         }
@@ -106,7 +97,7 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
             .collect();
         opts.par_iter().for_each(|entry| {
             // TODO split copy and sign
-            // for copying, we need to know source path, addons folder and pbo_filename 
+            // for copying, we need to know source path, addons folder and pbo_filename
             // (we could get this but that seems like extra faff)
             // for signing, we need to know addons folder, PBO file name and key
             if sign::copy_sign(&folder, &entry.path(), &p, &key).unwrap_or_print() {

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -67,7 +67,7 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
 
         // Write the public key to disk
         public_key.write(
-            &mut std::fs::File::create(format!("releases/keys/{}.bikey", keyname)).unwrap(),
+            &mut std::fs::File::create(format!("releases/keys/{}.bikey", keyname)).unwrap_or_print(),
         )?;
     }
 
@@ -82,13 +82,13 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
     // Sign
     let mut folder = String::from("addons");
     let dirs: Vec<_> = fs::read_dir(&folder)
-        .unwrap()
-        .map(|file| file.unwrap())
+        .unwrap_or_print()
+        .map(|file| file.unwrap_or_print())
         .collect();
     dirs.par_iter().for_each(|entry| {
         // TODO split copy and sign
-        if sign::copy_sign(&folder, &entry.path(), &p, &key).unwrap() {
-            *count.lock().unwrap() += 1;
+        if sign::copy_sign(&folder, &entry.path(), &p, &key).unwrap_or_print() {
+            *count.lock().unwrap_or_print() += 1;
         }
     });
 
@@ -101,20 +101,20 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
             fs::create_dir_all(addonsfolder)?;
         }
         let opts: Vec<_> = fs::read_dir(&folder)
-            .unwrap()
-            .map(|file| file.unwrap())
+            .unwrap_or_print()
+            .map(|file| file.unwrap_or_print())
             .collect();
         opts.par_iter().for_each(|entry| {
             // TODO split copy and sign
             // for copying, we need to know source path, addons folder and pbo_filename (we could
             // get this but that seems like extra faff)
             // for signing, we need to know addons folder, PBO file name and key
-            if sign::copy_sign(&folder, &entry.path(), &p, &key).unwrap() {
-                *count.lock().unwrap() += 1;
+            if sign::copy_sign(&folder, &entry.path(), &p, &key).unwrap_or_print() {
+                *count.lock().unwrap_or_print() += 1;
             }
         });
     }
 
-    green!("Signed", *count.lock().unwrap());
+    green!("Signed", *count.lock().unwrap_or_print());
     Ok(())
 }

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -36,7 +36,7 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
     let mut key;
     let keyname = p.get_keyname();
     // Generate and store key if required
-    if p.reuse_private_key.unwrap_or(false) {
+    if p.reuse_private_key {
 
         // Make a new keypair if there isn't one already
         if !Path::new(&format!("releases/keys/{}.bikey", keyname)).exists() {

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -106,8 +106,8 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
             .collect();
         opts.par_iter().for_each(|entry| {
             // TODO split copy and sign
-            // for copying, we need to know source path, addons folder and pbo_filename (we could
-            // get this but that seems like extra faff)
+            // for copying, we need to know source path, addons folder and pbo_filename 
+            // (we could get this but that seems like extra faff)
             // for signing, we need to know addons folder, PBO file name and key
             if sign::copy_sign(&folder, &entry.path(), &p, &key).unwrap_or_print() {
                 *count.lock().unwrap_or_print() += 1;

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -3,7 +3,8 @@ use glob::glob;
 use rayon::prelude::*;
 
 use std::fs;
-use std::io::{Error};
+use std::fs::File;
+use std::io::Error;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -94,8 +94,8 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
 
     folder = String::from("optionals");
     if Path::new(&folder).exists() {
-        let addonsfolder = format!(
-            "releases/{ver}/@{mod}/{addons}", ver=version, mod=modname, addons=folder
+        let addonsfolder = iformat!(
+            "releases/{version}/@{modname}/{folder}", version, modname, folder
         );
         if !Path::new(&addonsfolder).exists() {
             fs::create_dir_all(addonsfolder)?;

--- a/src/build/sign.rs
+++ b/src/build/sign.rs
@@ -40,9 +40,10 @@ pub fn copy_sign(
     }
 
     let modname = p.get_modname();
+    let ver = p.version.clone().unwrap();
 
-    let addonsfolder = format!(
-        "releases/{ver}/@{mod}/{addons}", ver=p.version.clone().unwrap(), mod=modname, addons=folder
+    let addonsfolder = iformat!(
+        "releases/{ver}/@{modname}/{folder}", ver, modname, folder
     );
 
     copy(&path_posix, &addonsfolder, &pbo_filename)?;

--- a/src/build/sign.rs
+++ b/src/build/sign.rs
@@ -1,30 +1,53 @@
+use armake2::{pbo::PBO, sign::BISignVersion};
 use std::fs;
-use std::fs::DirEntry;
-use std::io::{Error};
+use std::fs::File;
+use std::io::Error;
 use std::path::PathBuf;
 
-use crate::error::*;
+pub fn copy(path_posix: &String, addonsfolder: &String, pbo_filename: &String) -> Result<bool, Error> {
+    fs::copy(path_posix, format!("{}/{}", addonsfolder, pbo_filename))?;
+    Ok(true)
+}
 
-pub fn copy_sign(folder: &String, entry: &DirEntry, p: &crate::project::Project, version: &String) -> Result<bool, Error> {
-    let path = entry.path();
-    let cpath = path.clone();
-    let cpath = cpath.to_str().unwrap().replace(r#"\"#,"/");
-    let pbo = cpath.replace((folder.clone() + "/").as_str(), "");
-    if !path.ends_with(".pbo") && !pbo.starts_with(p.prefix.as_str()) {
+pub fn sign(
+    pbo_filename: &String,
+    addonsfolder: &String,
+    p: &crate::project::Project,
+    key: &armake2::sign::BIPrivateKey,
+) -> Result<bool, Error> {
+    let pbo =
+        PBO::read(&mut File::open(PathBuf::from(format!("{}/{}", addonsfolder, pbo_filename))).expect("Failed to open PBO"))
+            .expect("Failed to read PBO");
+
+    let sig = key.sign(&pbo, BISignVersion::V3);
+    let signame = p.get_signame(&pbo_filename);
+    sig.write(&mut File::create(PathBuf::from(format!("{}/{}", addonsfolder, signame))).unwrap())?;
+
+    Ok(true)
+}
+
+pub fn copy_sign(
+    folder: &String,
+    path: &PathBuf,
+    p: &crate::project::Project,
+    key: &armake2::sign::BIPrivateKey,
+) -> Result<bool, Error> {
+    let path_posix = path.clone().to_str().unwrap().replace(r#"\"#, "/");
+    let pbo_filename = path.file_name().unwrap().to_str().unwrap().to_string();
+
+    if !path.ends_with(".pbo") && !pbo_filename.starts_with(p.prefix.as_str()) {
         return Ok(false);
     }
 
     let modname = p.get_modname();
-    fs::copy(&cpath, format!("releases/{}/@{}/{}/{}", version, modname, folder, pbo))?;
 
-    let signame = p.get_signame(&pbo);
-    let keyname = p.get_keyname();
+    let addonsfolder = format!(
+        "releases/{ver}/@{mod}/{addons}", ver=p.version.clone().unwrap(), mod=modname, addons=folder
+    );
 
-    armake2::sign::cmd_sign(
-        PathBuf::from(format!("releases/keys/{}.biprivatekey", keyname)),
-        PathBuf::from(format!("releases/{}/@{}/{}/{}", version, modname, folder, pbo)),
-        Some(PathBuf::from(format!("releases/{0}/@{1}/{2}/{3}", version, modname, folder, signame))),
-        armake2::sign::BISignVersion::V3
-    ).print();
+    copy(&path_posix, &addonsfolder, &pbo_filename)?;
+
+    sign(&pbo_filename, &addonsfolder, p, key)?;
+
     Ok(true)
 }

--- a/src/build/sign.rs
+++ b/src/build/sign.rs
@@ -42,9 +42,7 @@ pub fn copy_sign(
     let modname = p.get_modname();
     let ver = p.version.clone().unwrap();
 
-    let addonsfolder = iformat!(
-        "releases/{ver}/@{modname}/{folder}", ver, modname, folder
-    );
+    let addonsfolder = iformat!("releases/{ver}/@{modname}/{folder}", ver, modname, folder);
 
     copy(&path_posix, &addonsfolder, &pbo_filename)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,3 +389,5 @@ fn ansi_support() {
 fn ansi_support() {
     unreachable!();
 }
+
+fn dft_false() -> bool { false }

--- a/src/project.rs
+++ b/src/project.rs
@@ -63,6 +63,8 @@ pub struct Project {
 
     #[serde(skip_deserializing,skip_serializing)]
     pub template_data: BTreeMap<&'static str, String>,
+
+    pub reuse_private_key: Option<bool>,
 }
 
 fn default_include() -> Vec<PathBuf> {
@@ -97,7 +99,11 @@ impl Project {
 
     pub fn get_keyname(&self) -> String {
         if self.keyname.is_empty() {
-            self.prefix.clone()
+            if self.reuse_private_key.unwrap_or(false) {
+                self.prefix.clone()
+            } else {
+                format!("{}_{}", &self.prefix, &self.version.clone().unwrap())
+            }
         } else {
             render(&self.keyname, &self.template_data)
         }
@@ -162,6 +168,7 @@ pub fn init(name: String, prefix: String, author: String) -> Result<Project, Err
         postbuild: Vec::new(),
         releasebuild: Vec::new(),
         scripts: HashMap::new(),
+        reuse_private_key: Some(false),
 
         template_data: BTreeMap::new(),
     };

--- a/src/project.rs
+++ b/src/project.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use crate::error::*;
 use crate::template::render;
 use crate::state::State;
+use crate::dft_false;
 
 #[derive(Serialize, Deserialize)]
 pub struct Project {
@@ -61,10 +62,12 @@ pub struct Project {
     #[serde(default = "HashMap::new")]
     pub scripts: HashMap<String, crate::build::script::BuildScript>,
 
+    #[serde(default = "dft_false")]
+    pub reuse_private_key: bool,
+
     #[serde(skip_deserializing,skip_serializing)]
     pub template_data: BTreeMap<&'static str, String>,
 
-    pub reuse_private_key: Option<bool>,
 }
 
 fn default_include() -> Vec<PathBuf> {
@@ -99,7 +102,7 @@ impl Project {
 
     pub fn get_keyname(&self) -> String {
         if self.keyname.is_empty() {
-            if self.reuse_private_key.unwrap_or(false) {
+            if self.reuse_private_key {
                 self.prefix.clone()
             } else {
                 format!("{}_{}", &self.prefix, &self.version.clone().unwrap())
@@ -168,7 +171,7 @@ pub fn init(name: String, prefix: String, author: String) -> Result<Project, Err
         postbuild: Vec::new(),
         releasebuild: Vec::new(),
         scripts: HashMap::new(),
-        reuse_private_key: Some(false),
+        reuse_private_key: false,
 
         template_data: BTreeMap::new(),
     };


### PR DESCRIPTION
Closes #42.

~~I haven't left writing the private key to disk as an option. The only valid usage I can think of is if you needed to distribute signing across a server farm, which you don't.~~

~~I've cheekily made the public key follow the `name_version.bikey` format since there will be a different one for each version now.~~

~~I've just spotted #47. I'm happy to rebase this on that once it has been merged.~~


---

- Don't write private key to disk unless `reuse_private_key` is set to true in the project configuration
    - If it is set to true, revert to the old behaviour
- Change the default key name to include the version if `reuse_private_key` is false, stick with old default otherwise

- Split copy / sign up into separate functions and do a bit of tidying up (I went a bit off-piste, sorry...)