### PR TITLE
Install CA Certificates in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN cargo install --path .
 FROM ubuntu:18.04
 
 RUN \
-	apt-get update && apt-get install -y git python3 zip --no-install-recommends && \
+	apt-get update && apt-get install -y git python3 zip ca-certificates --no-install-recommends && \
 	rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /usr/local/cargo/bin/hemtt /usr/local/bin/hemtt


### PR DESCRIPTION
ca certificates is necessary for running hemtt create due to the call to github with `create_include`
