### PR TITLE
Fix sign pbo file prefix check

### DIFF
--- a/src/build/sign.rs
+++ b/src/build/sign.rs
@@ -10,7 +10,7 @@ pub fn copy_sign(folder: &String, entry: &DirEntry, p: &crate::project::Project,
     let cpath = path.clone();
     let cpath = cpath.to_str().unwrap().replace(r#"\"#,"/");
     let pbo = cpath.replace((folder.clone() + "/").as_str(), "");
-    if !path.ends_with(".pbo") && !pbo.contains(p.prefix.as_str()) {
+    if !path.ends_with(".pbo") && !pbo.starts_with(p.prefix.as_str()) {
         return Ok(false);
     }
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix ACE3 `tracers` panic on release build

ACE3's `tracers` optional caused panic on release build, due to including the prefix `ace` (`trACErs`).

I am not sure this is the ideal solution, but I think it was intended to check only start anyways.