### PR TITLE
Document convertproject on help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,7 @@ Commands:
     build               Build the project
     clean               Clean build files
     update              Update HEMTT
+    convertproject      Convert hemtt.json to hemtt.toml
 
 Utilities:
     translation         Displays the translation progress of all stringtable files

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,8 +67,8 @@ Commands:
     update              Update HEMTT
 
 Utilities:
-    convertproject      Convert project file between JSON and TOML
     translation         Displays the translation progress of all stringtable files
+    convertproject      Convert project file between JSON and TOML
 
 Options:
     -v --verbose        Enable verbose output

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,9 @@ Commands:
     build               Build the project
     clean               Clean build files
     update              Update HEMTT
-    convertproject      Convert project file between JSON and TOML
 
 Utilities:
+    convertproject      Convert project file between JSON and TOML
     translation         Displays the translation progress of all stringtable files
 
 Options:

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ Commands:
     build               Build the project
     clean               Clean build files
     update              Update HEMTT
-    convertproject      Convert hemtt.json to hemtt.toml
+    convertproject      Convert project file between JSON and TOML
 
 Utilities:
     translation         Displays the translation progress of all stringtable files


### PR DESCRIPTION
`convertproject` wasn't listed under `--help`
