### PR TITLE
Add `rustfmt` CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ install:
   - source ~/.cargo/env || true
 
 script:
+  - cargo fmt --all -- --check
   - bash ci/script.sh
 
 after_script: set +e

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,12 @@
+max_width = 125
+hard_tabs = false
+newline_style = "Unix"
+use_small_heuristics = "Default"
+reorder_imports = true
+reorder_modules = true
+remove_nested_parens = true
+edition = "2018"
+merge_derives = true
+use_try_shorthand = true
+use_field_init_shorthand = true
+force_explicit_abi = true


### PR DESCRIPTION
- Adds a step to the Travis build that checks that `rustfmt` is a no-op and errors if it isn't.

I can't see any nice way of distributing pre-commit hooks, so I gave up on that idea.

Closes #38, sort of.

With a bit of luck, this will fail the Travis check - I'll push a commit that reformats everything afterwards.

Happy to bikeshed on the options. `max_width` is probably what people care about the most. I've increased it from its default of 100 already.

Edit: looks like I need to do `rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu`, presumably different for each target, presumably in `ci/install.sh`. I'll have a look ~~tomorrow~~ someday.