### PR TITLE
Macros

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -31,7 +31,7 @@ pub fn modtime(addon: &Path) -> Result<SystemTime, Error> {
 }
 
 pub fn addons(p: &crate::project::Project, addons: &Vec<PathBuf>) -> Result<BuildResult, Error> {
-    println!("  {} {}", "Building".green().bold(), addons.len());
+    crate::green!("Building", addons.len());
     let mut pb = ProgressBar::new(addons.len() as u64);
     pb.show_speed = false;
     pb.show_time_left = false;
@@ -67,10 +67,10 @@ pub fn addons(p: &crate::project::Project, addons: &Vec<PathBuf>) -> Result<Buil
     }, buildresult.built.len(), crate::repeat!(" ", 50)));
     println!();
     if buildresult.failed.len() != 0 {
-        println!("    {} {} {:?}", "Failed".red().bold(), buildresult.failed.len(), buildresult.failed);
+        crate::red!("Failed", format!("{} {:?}", buildresult.failed.len(), buildresult.failed));
     }
     if buildresult.skipped.len() != 0 {
-        println!("   {} {}", "Skipped".bold(), buildresult.skipped.len());
+        crate::white!("Skipped", buildresult.skipped.len());
     }
     Ok(buildresult)
 }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -31,7 +31,7 @@ pub fn modtime(addon: &Path) -> Result<SystemTime, Error> {
 }
 
 pub fn addons(p: &crate::project::Project, addons: &Vec<PathBuf>) -> Result<BuildResult, Error> {
-    crate::green!("Building", addons.len());
+    green!("Building", addons.len());
     let mut pb = ProgressBar::new(addons.len() as u64);
     pb.show_speed = false;
     pb.show_time_left = false;
@@ -64,13 +64,13 @@ pub fn addons(p: &crate::project::Project, addons: &Vec<PathBuf>) -> Result<Buil
     pbm.lock().unwrap().finish_print(&format!("\r     {} {} {}", match buildresult.failed.len() {
         0 => "Built".green().bold(),
         _ => "Built".yellow().bold()
-    }, buildresult.built.len(), crate::repeat!(" ", 50)));
+    }, buildresult.built.len(), repeat!(" ", 50)));
     println!();
     if buildresult.failed.len() != 0 {
-        crate::red!("Failed", format!("{} {:?}", buildresult.failed.len(), buildresult.failed));
+        red!("Failed", format!("{} {:?}", buildresult.failed.len(), buildresult.failed));
     }
     if buildresult.skipped.len() != 0 {
-        crate::white!("Skipped", buildresult.skipped.len());
+        white!("Skipped", buildresult.skipped.len());
     }
     Ok(buildresult)
 }
@@ -81,7 +81,7 @@ fn _build(p: &crate::project::Project, source: &PathBuf, target: &PathBuf, pbm: 
         let metadata = fs::metadata(target).unwrap();
         if let Ok(time) = metadata.modified() {
             if time >= modified {
-                // println!("\r  {} {}{}", "Skipping".white().bold(), name, crate::repeat!(" ", 50 - name.len()));
+                // println!("\r  {} {}{}", "Skipping".white().bold(), name, repeat!(" ", 50 - name.len()));
                 if let Some(ref pb) = pbm {
                     let mut pbu = pb.lock().unwrap();
                     pbu.tick();
@@ -93,7 +93,7 @@ fn _build(p: &crate::project::Project, source: &PathBuf, target: &PathBuf, pbm: 
         }
     }
 
-    // println!("\r  {} {}{}", "Building".green().bold(), name, crate::repeat!(" ", 50 - name.len()));
+    // println!("\r  {} {}{}", "Building".green().bold(), name, repeat!(" ", 50 - name.len()));
     if let Some(ref pb) = pbm {
         let mut pbu = pb.lock().unwrap();
         pbu.tick();
@@ -113,7 +113,7 @@ fn _build(p: &crate::project::Project, source: &PathBuf, target: &PathBuf, pbm: 
         &include,               // Include folders
     ) {
         let name = source.to_str().unwrap().to_owned();
-        eprintln!("\r{}: {}{}\n{}", "error".red().bold(), name, crate::repeat!(" ", 53 - name.len()), error);
+        eprintln!("\r{}: {}{}\n{}", "error".red().bold(), name, repeat!(" ", 53 - name.len()), error);
         if target.exists() {
             fs::remove_file(target)?;
         }

--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -10,7 +10,6 @@ use rayon::prelude::*;
 use std::fs;
 use std::fs::File;
 use std::io::{Error};
-use std::iter::repeat;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, Instant};

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -24,7 +24,7 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
     }
     let keyname = p.get_keyname();
     if !Path::new(&format!("releases/keys/{}.bikey", keyname)).exists() {
-        println!("    {} {}.bikey", "KeyGen".green().bold(), keyname);
+        green!("KeyGen", &keyname);
         armake2::sign::cmd_keygen(PathBuf::from(&keyname))?;
         fs::rename(format!("{}.bikey", keyname), format!("releases/keys/{}.bikey", keyname))?;
         fs::rename(format!("{}.biprivatekey", keyname), format!("releases/keys/{}.biprivatekey", keyname))?;
@@ -62,6 +62,6 @@ pub fn release(p: &crate::project::Project, version: &String) -> Result<(), Erro
         });
     }
 
-    println!("    {} {}", "Signed".green().bold(), *count.lock().unwrap());
+    green!("Signed", *count.lock().unwrap());
     Ok(())
 }

--- a/src/build/script.rs
+++ b/src/build/script.rs
@@ -86,7 +86,7 @@ impl BuildScript {
                         });
                         //pbm.lock().unwrap().pb().finish_print(&nicefmt!(green, "Executed", format!("{}{}", state.addons.len(), crate::repeat!(" ", 60))));
                         //println!();
-                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
+                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
                     },
                     Stage::PostBuild | Stage::ReleaseBuild => {
                         let built = &state.result.unwrap().built;
@@ -95,7 +95,7 @@ impl BuildScript {
                             self.run_pboresult(&p, &addon, &steps, &state, &pbm).unwrap_or_print();
                             pbm.lock().unwrap().pb().inc();
                         });
-                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", built.len());
+                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", built.len());
                     },
                     _ => {}
                 }
@@ -107,7 +107,7 @@ impl BuildScript {
                             self.run_pathbuf(&p, &addon, &steps, &state, &pbm)?;
                             pbm.lock().unwrap().pb().inc();
                         }
-                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
+                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
                     },
                     Stage::PostBuild | Stage::ReleaseBuild => {
                         let built = &state.result.unwrap().built;
@@ -116,7 +116,7 @@ impl BuildScript {
                             self.run_pboresult(&p, &addon, &steps, &state, &pbm)?;
                             pbm.lock().unwrap().pb().inc();
                         }
-                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", built.len());
+                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", built.len());
                     },
                     _ => {}
                 }

--- a/src/build/script.rs
+++ b/src/build/script.rs
@@ -84,8 +84,9 @@ impl BuildScript {
                             self.run_pathbuf(&p, &addon, &steps, &state, &pbm).unwrap_or_print();
                             pbm.lock().unwrap().pb().inc();
                         });
-                        pbm.lock().unwrap().pb().finish_print(&format!("  {} {}{}", "Executed".green().bold(), state.addons.len(), crate::repeat!(" ", 60)));
-                        println!();
+                        //pbm.lock().unwrap().pb().finish_print(&nicefmt!(green, "Executed", format!("{}{}", state.addons.len(), crate::repeat!(" ", 60))));
+                        //println!();
+                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
                     },
                     Stage::PostBuild | Stage::ReleaseBuild => {
                         let built = &state.result.unwrap().built;
@@ -94,8 +95,7 @@ impl BuildScript {
                             self.run_pboresult(&p, &addon, &steps, &state, &pbm).unwrap_or_print();
                             pbm.lock().unwrap().pb().inc();
                         });
-                        pbm.lock().unwrap().pb().finish_print(&format!("  {} {}{}", "Executed".green().bold(), built.len(), crate::repeat!(" ", 60)));
-                        println!()
+                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", built.len());
                     },
                     _ => {}
                 }
@@ -107,8 +107,7 @@ impl BuildScript {
                             self.run_pathbuf(&p, &addon, &steps, &state, &pbm)?;
                             pbm.lock().unwrap().pb().inc();
                         }
-                        pbm.lock().unwrap().pb().finish_print(&format!("  {} {}{}", "Executed".green().bold(), state.addons.len(), crate::repeat!(" ", 60)));
-                        println!();
+                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
                     },
                     Stage::PostBuild | Stage::ReleaseBuild => {
                         let built = &state.result.unwrap().built;
@@ -117,8 +116,7 @@ impl BuildScript {
                             self.run_pboresult(&p, &addon, &steps, &state, &pbm)?;
                             pbm.lock().unwrap().pb().inc();
                         }
-                        pbm.lock().unwrap().pb().finish_print(&format!("  {} {}{}", "Executed".green().bold(), built.len(), crate::repeat!(" ", 60)));
-                        println!()
+                        crate::finishpb(pbm.lock().unwrap().pb(), green, "Executed", built.len());
                     },
                     _ => {}
                 }
@@ -211,6 +209,7 @@ fn execute(p: &crate::project::Project, command: &String, state: &State, output:
         None => ""
     };
     match name.remove(0) {
+        // TODO replace println with color macros, need to deal with that prefix
         '@' => {
             if output {println!("{}   {} {}", prefix, "Utility".green().bold(), &name)};
             match crate::utilities::find(&name) {

--- a/src/build/script.rs
+++ b/src/build/script.rs
@@ -6,7 +6,6 @@ use subprocess::Exec;
 
 use std::path::PathBuf;
 use std::io::Error;
-use std::iter::repeat;
 use std::sync::{Arc, Mutex};
 
 use crate::error;

--- a/src/build/script.rs
+++ b/src/build/script.rs
@@ -84,9 +84,9 @@ impl BuildScript {
                             self.run_pathbuf(&p, &addon, &steps, &state, &pbm).unwrap_or_print();
                             pbm.lock().unwrap().pb().inc();
                         });
-                        //pbm.lock().unwrap().pb().finish_print(&nicefmt!(green, "Executed", format!("{}{}", state.addons.len(), crate::repeat!(" ", 60))));
+                        //pbm.lock().unwrap().pb().finish_print(&nicefmt!(green, "Executed", format!("{}{}", state.addons.len(), repeat!(" ", 60))));
                         //println!();
-                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
+                        finishpb!(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
                     },
                     Stage::PostBuild | Stage::ReleaseBuild => {
                         let built = &state.result.unwrap().built;
@@ -95,7 +95,7 @@ impl BuildScript {
                             self.run_pboresult(&p, &addon, &steps, &state, &pbm).unwrap_or_print();
                             pbm.lock().unwrap().pb().inc();
                         });
-                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", built.len());
+                        finishpb!(pbm.lock().unwrap().pb(), green, "Executed", built.len());
                     },
                     _ => {}
                 }
@@ -107,7 +107,7 @@ impl BuildScript {
                             self.run_pathbuf(&p, &addon, &steps, &state, &pbm)?;
                             pbm.lock().unwrap().pb().inc();
                         }
-                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
+                        finishpb!(pbm.lock().unwrap().pb(), green, "Executed", state.addons.len());
                     },
                     Stage::PostBuild | Stage::ReleaseBuild => {
                         let built = &state.result.unwrap().built;
@@ -116,7 +116,7 @@ impl BuildScript {
                             self.run_pboresult(&p, &addon, &steps, &state, &pbm)?;
                             pbm.lock().unwrap().pb().inc();
                         }
-                        crate::finishpb!(pbm.lock().unwrap().pb(), green, "Executed", built.len());
+                        finishpb!(pbm.lock().unwrap().pb(), green, "Executed", built.len());
                     },
                     _ => {}
                 }
@@ -136,7 +136,7 @@ impl BuildScript {
         }
         let mut data = p.template_data.clone();
         let name = addon.file_name().unwrap().to_str().unwrap().to_owned();
-        pbm.lock().unwrap().pb().message(&format!("{}{} ", &name, crate::repeat!(" ",
+        pbm.lock().unwrap().pb().message(&format!("{}{} ", &name, repeat!(" ",
             if &name.len() > &20 {0} else {20 - &name.len()}
         )));
         data.insert("addon", name.clone());
@@ -157,7 +157,7 @@ impl BuildScript {
         }
         let mut data = p.template_data.clone();
         let name = addon.source.file_name().unwrap().to_str().unwrap().to_owned();
-        pbm.lock().unwrap().pb().message(&format!("{}{} ", &name, crate::repeat!(" ",
+        pbm.lock().unwrap().pb().message(&format!("{}{} ", &name, repeat!(" ",
             if &name.len() > &20 {0} else {20 - &name.len()}
         )));
         data.insert("addon", name.clone());
@@ -231,14 +231,14 @@ fn execute(p: &crate::project::Project, command: &String, state: &State, output:
         },
         _   => {
             let cmd = command.clone().replace("\\", "\\\\");
-            if output {println!("{} {} {}{}", prefix, "Executing".green().bold(), &cmd.bold(), crate::repeat!(" ", 60 - &cmd.len()))};
+            if output {println!("{} {} {}{}", prefix, "Executing".green().bold(), &cmd.bold(), repeat!(" ", 60 - &cmd.len()))};
             if let Some(_) = &pb {
                 &pb.unwrap().pb().tick();
             }
             let out = Exec::shell(&command).capture().unwrap_or_print().stdout_str();
             if output {
                 for line in out.lines() {
-                    println!("{}           {}{}", prefix, line, crate::repeat!(" ", 70 - line.len()));
+                    println!("{}           {}{}", prefix, line, repeat!(" ", 70 - line.len()));
                 }
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,22 +1,6 @@
-#![macro_use]
-
 use colored::*;
 
 use std::fmt::{Debug, Display};
-
-#[macro_export]
-macro_rules! error {
-    ($($arg:tt)*) => (
-        std::io::Error::new(std::io::ErrorKind::Other, format!($($arg)*))
-    )
-}
-
-#[macro_export]
-macro_rules! warn {
-    ($($arg:tt)*) => {
-        eprintln!("{}: {}", "warning".yellow().bold(), format!($($arg)*))
-    }
-}
 
 pub trait ErrorExt<T, E> {
     fn print(self) -> Option<T>;

--- a/src/files.rs
+++ b/src/files.rs
@@ -23,7 +23,7 @@ pub fn clear_pbos(p: &project::Project, addons: &Vec<PathBuf>) -> Result<(), Err
                 fs::remove_file(target).print();
             }
         });
-    println!("   {} {} PBOs", "Cleaned".yellow().bold(), *count.lock().unwrap());
+    crate::yellow!("Cleaned", format!("{} PBOs", *count.lock().unwrap()));
     Ok(())
 }
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -23,7 +23,7 @@ pub fn clear_pbos(p: &project::Project, addons: &Vec<PathBuf>) -> Result<(), Err
                 fs::remove_file(target).print();
             }
         });
-    crate::yellow!("Cleaned", format!("{} PBOs", *count.lock().unwrap()));
+    yellow!("Cleaned", format!("{} PBOs", *count.lock().unwrap()));
     Ok(())
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,34 @@
+#[macro_export]
+macro_rules! iprintln {
+    ($e:expr, $($p:ident),*) => {
+        println!($e, $($p = $p,)*);
+    };
+}
+
+#[macro_export]
+macro_rules! iprint {
+    ($e:expr, $($p:ident),*) => {
+        print!($e, $($p = $p,)*);
+    };
+}
+
+#[macro_export]
+macro_rules! ieprintln {
+    ($e:expr, $($p:ident),*) => {
+        eprintln!($e, $($p = $p,)*);
+    };
+}
+
+#[macro_export]
+macro_rules! ieprint {
+    ($e:expr, $($p:ident),*) => {
+        eprint!($e, $($p = $p,)*);
+    };
+}
+
+#[macro_export]
+macro_rules! repeat {
+    ($s: expr, $n: expr) => {{
+        &repeat($s).take($n).collect::<String>()
+    }}
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,4 @@
-#[macro_use]
+// String Interpolation
 
 #[macro_export]
 macro_rules! iprintln {
@@ -35,66 +35,61 @@ macro_rules! iformat {
     };
 }
 
-#[macro_export]
-macro_rules! repeat {
-    ($s:expr, $n:expr) => {{
-        &std::iter::repeat($s).take($n).collect::<String>()
-    }}
-}
+// Colored Output
 
 #[macro_export]
 macro_rules! yellow {
     ($s:expr, $m:expr) => {
-        crate::niceout!(yellow, $s, $m);
+        crate::niceprintln!(yellow, $s, $m);
     }
 }
 
 #[macro_export]
 macro_rules! blue {
     ($s:expr, $m:expr) => {
-        crate::niceout!(blue, $s, $m);
+        crate::niceprintln!(blue, $s, $m);
     }
 }
 
 #[macro_export]
 macro_rules! green {
     ($s:expr, $m:expr) => {
-        crate::niceout!(green, $s, $m);
+        crate::niceprintln!(green, $s, $m);
     }
 }
 
 #[macro_export]
 macro_rules! cyan {
     ($s:expr, $m:expr) => {
-        crate::niceout!(cyan, $s, $m);
+        crate::niceprintln!(cyan, $s, $m);
     }
 }
 
 #[macro_export]
 macro_rules! magenta {
     ($s:expr, $m:expr) => {
-        crate::niceout!(magenta, $s, $m);
+        crate::niceprintln!(magenta, $s, $m);
     }
 }
 
 #[macro_export]
 macro_rules! red {
     ($s:expr, $m:expr) => {
-        crate::niceout!(red, $s, $m);
+        crate::niceprintln!(red, $s, $m);
     }
 }
 
 #[macro_export]
 macro_rules! black {
     ($s:expr, $m:expr) => {
-        crate::niceout!(black, $s, $m);
+        crate::niceprintln!(black, $s, $m);
     }
 }
 
 #[macro_export]
 macro_rules! white {
     ($s:expr, $m:expr) => {
-        crate::niceout!(white, $s, $m);
+        crate::niceprintln!(white, $s, $m);
     }
 }
 
@@ -109,7 +104,7 @@ macro_rules! nicefmt {
 }
 
 #[macro_export]
-macro_rules! niceout {
+macro_rules! niceprintln {
     ($c:ident, $s:expr, $m:expr) => {
         let r = crate::nicefmt!($c, $s, $m);
         println!("{}", r);
@@ -122,6 +117,31 @@ macro_rules! finishpb {
         let message =  format!("{}{}", $m, crate::repeat!(" ", 60));
         $pb.finish_print(&crate::nicefmt!($c, $s, message));
         println!();
+    }}
+}
+
+// Errors and Warnings
+
+#[macro_export]
+macro_rules! error {
+    ($($arg:tt)*) => (
+        std::io::Error::new(std::io::ErrorKind::Other, format!($($arg)*))
+    )
+}
+
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => {
+        eprintln!("{}: {}", "warning".yellow().bold(), format!($($arg)*))
+    }
+}
+
+// Generic
+
+#[macro_export]
+macro_rules! repeat {
+    ($s:expr, $n:expr) => {{
+        &std::iter::repeat($s).take($n).collect::<String>()
     }}
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -100,28 +100,29 @@ macro_rules! white {
 
 #[macro_export]
 macro_rules! nicefmt {
-    ($c:ident, $s:expr, $m:expr) => {
+    ($c:ident, $s:expr, $m:expr) => {{
         let status = $s.$c().bold();
         let spacer = crate::repeat!(" ", 10 - $s.len());
         let message = $m;
-        format!("{spacer}{status} {message}", spacer, status, message)
-    }
+        crate::iformat!("{spacer}{status} {message}", spacer, status, message)
+    }}
 }
 
 #[macro_export]
 macro_rules! niceout {
     ($c:ident, $s:expr, $m:expr) => {
-        crate::iprintln!($c, $s, $m);
+        let r = crate::nicefmt!($c, $s, $m);
+        println!("{}", r);
     }
 }
 
 #[macro_export]
 macro_rules! finishpb {
-    ($pb:ident, $c:ident, $s:expr, $m:expr) => {
-        let message =  format!("{}{}", $m, crate::repeat!(" ", 60);
-        $pb().finish_print(&crate::nicefmt!($c, $s, message)));
+    ($pb:expr, $c:ident, $s:expr, $m:expr) => {{
+        let message =  format!("{}{}", $m, crate::repeat!(" ", 60));
+        $pb.finish_print(&crate::nicefmt!($c, $s, message));
         println!();
-    }
+    }}
 }
 
 #[cfg(test)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,5 @@
+#[macro_use]
+
 #[macro_export]
 macro_rules! iprintln {
     ($e:expr, $($p:ident),*) => {
@@ -35,9 +37,91 @@ macro_rules! iformat {
 
 #[macro_export]
 macro_rules! repeat {
-    ($s: expr, $n: expr) => {{
+    ($s:expr, $n:expr) => {{
         &std::iter::repeat($s).take($n).collect::<String>()
     }}
+}
+
+#[macro_export]
+macro_rules! yellow {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(yellow, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! blue {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(blue, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! green {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(green, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! cyan {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(cyan, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! magenta {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(magenta, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! red {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(red, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! black {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(black, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! white {
+    ($s:expr, $m:expr) => {
+        crate::niceout!(white, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! nicefmt {
+    ($c:ident, $s:expr, $m:expr) => {
+        let status = $s.$c().bold();
+        let spacer = crate::repeat!(" ", 10 - $s.len());
+        let message = $m;
+        format!("{spacer}{status} {message}", spacer, status, message)
+    }
+}
+
+#[macro_export]
+macro_rules! niceout {
+    ($c:ident, $s:expr, $m:expr) => {
+        crate::iprintln!($c, $s, $m);
+    }
+}
+
+#[macro_export]
+macro_rules! finishpb {
+    ($pb:ident, $c:ident, $s:expr, $m:expr) => {
+        let message =  format!("{}{}", $m, crate::repeat!(" ", 60);
+        $pb().finish_print(&crate::nicefmt!($c, $s, message)));
+        println!();
+    }
 }
 
 #[cfg(test)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,8 +27,29 @@ macro_rules! ieprint {
 }
 
 #[macro_export]
+macro_rules! iformat {
+    ($e:expr, $($p:ident),*) => {
+        format!($e, $($p = $p,)*);
+    };
+}
+
+#[macro_export]
 macro_rules! repeat {
     ($s: expr, $n: expr) => {{
-        &repeat($s).take($n).collect::<String>()
+        &std::iter::repeat($s).take($n).collect::<String>()
     }}
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_format() {
+        let name = "HEMTT";
+        assert_eq!("Hello HEMTT", iformat!("Hello {name}", name));
+    }
+
+    #[test]
+    fn test_repeat() {
+        assert_eq!("....", repeat!(".", 4));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,9 @@ use num_cpus;
 use self_update;
 use serde::Deserialize;
 
+#[macro_use]
+pub mod macros;
+
 #[cfg(windows)]
 use ansi_term;
 
@@ -16,7 +19,6 @@ mod build;
 mod error;
 mod files;
 mod helpers;
-mod macros;
 mod project;
 mod state;
 mod template;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,16 +16,14 @@ mod build;
 mod error;
 mod files;
 mod helpers;
+mod macros;
 mod project;
 mod state;
 mod template;
 mod utilities;
-#[macro_use]
-mod macros;
 
 use crate::error::*;
 use crate::utilities::Utility;
-pub use crate::macros::*;
 
 #[allow(non_snake_case)]
 #[cfg(debug_assertions)]
@@ -336,6 +334,9 @@ fn main() {
     if cfg!(windows) {
         ansi_support();
     }
+
+    yellow!("Testing", "This is a test");
+    blue!("test", "This is yet another test");
 
     let mut args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,9 +337,6 @@ fn main() {
         ansi_support();
     }
 
-    yellow!("Testing", "This is a test");
-    blue!("test", "This is yet another test");
-
     let mut args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,16 +20,12 @@ mod project;
 mod state;
 mod template;
 mod utilities;
+#[macro_use]
+mod macros;
 
 use crate::error::*;
 use crate::utilities::Utility;
-
-#[macro_export]
-macro_rules! repeat {
-    ($s: expr, $n: expr) => {{
-        &repeat($s).take($n).collect::<String>()
-    }}
-}
+pub use crate::macros::*;
 
 #[allow(non_snake_case)]
 #[cfg(debug_assertions)]


### PR DESCRIPTION
Create macros allowing for faux string interpolation without redundant declaration like named parameters use.

```rust
let name = "Brett";
iprintln!("Hello {name}", name);
```
compared to the rust
```rust
let name = "Brett";
println!("Hello {name}", name = name);
```