### PR TITLE
Try to improve errors on dodgy JSON

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use std::fmt::{Debug, Display};
 pub trait ErrorExt<T, E> {
     fn print(self) -> Option<T>;
     fn unwrap_or_print(self) -> T;
+    fn unwrap_or_print_with_context(self, context: &str) -> T;
 }
 impl<T, E: Debug + Display> ErrorExt<T, E> for Result<T, E> {
     fn print(self) -> Option<T> {
@@ -14,11 +15,14 @@ impl<T, E: Debug + Display> ErrorExt<T, E> for Result<T, E> {
         }
         Some(self.unwrap())
     }
-    fn unwrap_or_print(self) -> T {
+    fn unwrap_or_print_with_context(self, context: &str) -> T {
         if let Err(error) = &self {
-            eprintln!("{}: {}", "error".red().bold(), error);
+            eprintln!("{}: {}{}", "error".red().bold(), context, error);
             std::process::exit(1);
         }
         self.unwrap()
+    }
+    fn unwrap_or_print(self) -> T {
+        self.unwrap_or_print_with_context("")
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ fn run_command(args: &Args) -> Result<(), Error> {
         Ok(())
     } else if args.cmd_build {
         check(false, args.flag_force).unwrap_or_print();
-        let p = project::get_project().unwrap();
+        let p = project::get_project().unwrap_or_print();
         if !args.flag_nowarn {
             unsafe {
                 armake2::error::WARNINGS_MUTED = Some(HashSet::new());

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ fn run_command(args: &Args) -> Result<(), Error> {
         Ok(())
     } else if args.cmd_build {
         check(false, args.flag_force).unwrap_or_print();
-        let p = project::get_project().unwrap_or_print();
+        let p = project::get_project().unwrap_or_print_with_context("Could not parse project configuration: ");
         if !args.flag_nowarn {
             unsafe {
                 armake2::error::WARNINGS_MUTED = Some(HashSet::new());


### PR DESCRIPTION
If there's an error in hemtt.json (or toml, presumably?), you get a scary error like:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidData, error: Error("expected `:`", line: 4, column: 11) }', src/libcore/result.rs:1009:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

With the first commit in this PR, you get the slightly friendlier

```
error:  expected `:` at line 4 column 11
```

and with the second:

```
error: Could not parse project configuration: expected `:` at line 4 column 11
```

It still isn't ideal - it should really include the file name - but I think this is a worthwhile step in the right direction.
