### PR TITLE
default to v2 signatures

### DIFF
--- a/docs/project.md
+++ b/docs/project.md
@@ -209,6 +209,18 @@ HEMTT will use the specified signature name as part of the full signature (`.bis
 
 Above will result in signature name of `TST_<addon>.pbo.my-1.0.0.0.bisign` (where `<addon>` is the name of the addon folder), located next to the matching addon PBO.
 
+## sigversion
+**Type**: Integer
+
+HEMTT will use the specified signature version.  
+Currently Supported: V2, V3 (Experiemental).  
+Default: 2
+
+### Example
+
+```json
+"sigversion": 3
+```
 
 ## reuse_private_key
 

--- a/src/build/sign.rs
+++ b/src/build/sign.rs
@@ -1,4 +1,6 @@
 use armake2::{pbo::PBO, sign::BISignVersion};
+use colored::*;
+
 use std::fs;
 use std::fs::File;
 use std::io::Error;
@@ -19,7 +21,15 @@ pub fn sign(
         PBO::read(&mut File::open(PathBuf::from(format!("{}/{}", addonsfolder, pbo_filename))).expect("Failed to open PBO"))
             .expect("Failed to read PBO");
 
-    let sig = key.sign(&pbo, BISignVersion::V3);
+    let sig = match p.sigversion {
+        3 => key.sign(&pbo, BISignVersion::V3),
+        2 => key.sign(&pbo, BISignVersion::V2),
+        _ => {
+            yellow!("KeyWarn", format!("Invalid Version {}", p.sigversion));
+            yellow!("KeyWarn", "Using V2");
+            key.sign(&pbo, BISignVersion::V2)
+        }
+    };
     let signame = p.get_signame(&pbo_filename);
     sig.write(&mut File::create(PathBuf::from(format!("{}/{}", addonsfolder, signame))).unwrap())?;
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -50,6 +50,8 @@ pub struct Project {
     #[serde(skip_serializing_if = "String::is_empty")]
     #[serde(default = "String::new")]
     pub signame: String,
+    #[serde(default = "dft_sig")]
+    pub sigversion: u8,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default = "Vec::new")]
     pub prebuild: Vec<String>,
@@ -197,6 +199,7 @@ pub fn init(name: String, prefix: String, author: String) -> Result<Project, Err
         modname: String::new(),
         keyname: String::new(),
         signame: String::new(),
+        sigversion: dft_sig(),
         prebuild: Vec::new(),
         postbuild: Vec::new(),
         releasebuild: Vec::new(),
@@ -311,4 +314,8 @@ pub fn get_version() -> Result<SemVer, Error> {
 }
 fn get_version_unwrap() -> Option<String> {
     Some(get_version().unwrap().to_string())
+}
+
+fn dft_sig() -> u8 {
+    2
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Use V2 Signatures by default
- Add project level setting `sigversion`
