### PR TITLE
Support Launchable / Folder Optionals

### DIFF
--- a/docs/project.md
+++ b/docs/project.md
@@ -132,6 +132,15 @@ HEMTT will build the specified addons from the `./optionals` folder.
 ]
 ```
 
+## folder_optionals
+**Type**: Bool
+
+HEMTT will by default build optionals into their own mod folders, which can be directly launched by the user. This can be turned off to build optional PBOs directly into `optionals` folder.
+
+```json
+"folder_optionals": false
+```
+
 ## skip
 **Type**: Array \[String\]
 

--- a/src/build/release.rs
+++ b/src/build/release.rs
@@ -99,7 +99,8 @@ pub fn release(p: &crate::project::Project, version: &str) -> Result<(), Error> 
             .collect();
         opts.par_iter().for_each(|entry| {
             let addonfolder = if p.folder_optionals {
-                let optname = entry.path().file_stem().unwrap().to_str().unwrap().to_owned();
+                let optname = entry.path().file_stem().unwrap().to_str().unwrap().to_owned()
+                    .replace(&format!("{}_", p.prefix), &format!("{}_", modname));
                 let optfolder = iformat!("{addonsfolder}/@{optname}/addons", addonsfolder, optname);
                 if !Path::new(&optfolder).exists() {
                     fs::create_dir_all(&optfolder).unwrap_or_print();

--- a/src/build/sign.rs
+++ b/src/build/sign.rs
@@ -53,14 +53,8 @@ pub fn copy_sign(
         return Ok(false);
     }
 
-    let modname = p.get_modname();
-    let ver = p.version.clone().unwrap();
-
-    let addonsfolder = iformat!("releases/{ver}/@{modname}/{folder}", ver, modname, folder);
-
-    copy(&path_posix, &addonsfolder, &pbo_filename)?;
-
-    sign(&pbo_filename, &addonsfolder, p, key)?;
+    copy(&path_posix, &folder, &pbo_filename)?;
+    sign(&pbo_filename, &folder, p, key)?;
 
     Ok(true)
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -35,6 +35,9 @@ pub struct Project {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default = "Vec::new")]
     pub optionals: Vec<String>,
+    #[serde(skip_serializing_if = "crate::is_true")]
+    #[serde(default = "crate::dft_true")]
+    pub folder_optionals: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     #[serde(default = "Vec::new")]
     pub skip: Vec<String>,
@@ -194,6 +197,7 @@ pub fn init(name: String, prefix: String, author: String) -> Result<Project, Err
         include: Vec::new(),
         exclude: Vec::new(),
         optionals: Vec::new(),
+        folder_optionals: true,
         skip: Vec::new(),
         headerexts: Vec::new(),
         modname: String::new(),


### PR DESCRIPTION
**When merged this pull request will:**
- Build (by default) optionals into their own mod folders, allowing users to directly launch them.
- Cleanup `fn release` a bit
  - Base release folder variable
  - Filtering for files only
  - Pass path directly to `copy_sign`

Used in ACE3 and other projects - easier to do in HEMTT than custom build scripts, also makes more sense. Enabled by default, possible to disable.

TODO:
- [x] Documentation
- [x] Windows compatibility test