### PR TITLE
Optimize zip using flate2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,7 @@ dependencies = [
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zip 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zip 0.5.2 (git+https://github.com/jonpas/zip-rs?branch=flate2)",
 ]
 
 [[package]]
@@ -1972,6 +1972,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "zip"
 version = "0.5.2"
+source = "git+https://github.com/jonpas/zip-rs?branch=flate2#b171b915f820c139ce369b5ae30f41eb8519cd38"
+dependencies = [
+ "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "podio 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "zip"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2204,4 +2216,5 @@ dependencies = [
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"
+"checksum zip 0.5.2 (git+https://github.com/jonpas/zip-rs?branch=flate2)" = "<none>"
 "checksum zip 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c18fc320faf909036e46ac785ea827f72e485304877faf1a3a39538d3714dbc3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde-xml-rs = "0.3.1"
 subprocess = "0.1"
 toml = "0.5"
 walkdir = "2.2"
-zip = { version = "0.5.2", features = ["deflate"] }
+zip = { git = "https://github.com/jonpas/zip-rs", branch = "flate2", features = ["deflate"] }
 
 [target.'cfg(windows)'.dependencies]
 ansi_term = "0.11"


### PR DESCRIPTION
**When merged this pull request will:**
- Replace #133 
- Optimize `zip` utility (better than #133)
  - Using `flate2` (DE)FLATE implementation in `zip-rs` from [`jonpas/zip-rs [flate2]`](https://github.com/jonpas/zip-rs/tree/flate2) instead `libflate`
  - Ref. https://github.com/mvdnes/zip-rs/issues/88#issuecomment-491185791 and https://github.com/mvdnes/zip-rs/pull/107

In debug build, compared to #133, shaved off another ~30%. `release` build compression speeds are now on-par with 7z on Windows.

## Benchmarks

All benchmarks were ran on `release` build (`cargo build --release`).
- **Old**: HEMTT 249d6e8a37a3390a798bd7ad98bf9313b1dc2297
- **#133**: Pull request #133 (`BufReader`/`BufWriter`/`copy` optimization)
- **New**: **#133** + `flake2` implementation in `zip-rs` (instead of `libflate`)

_Difference in **ACE3** Folder Size is due to binarization._
_**Old** and **#133** Zip Size is the same as (DE)FLATE implementation is the same._

### Linux

Mod | Folder Size | Old Speed | #133 Speed | New Speed | Old / #133 Zip Size | New Zip Size
-------- | ------- | ----- | ----- | ----- | ------- | -------
**TACU** | 12.2 MB | 9 s   | 1.5 s | 0.5 s | 11.2 MB | 11.2 MB
**TACR** | 59.2 MB | 44 s  | 7.5 s | 2.5 s | 50.6 MB | 50.5 MB
**ACE3** | 205 MB  | 110 s | 15 s  | 7.2 s | 143 MB  | 139 MB

### Windows

Mod | Folder Size | Old Speed | #133 Speed | New Speed | Old / #133 Zip Size | New Zip Size
-------- | ------- | ----- | ----- | ----- | ------- | -------
**TACU** | 13 MB   | 13 s  | 2.5 s | 0.5 s | 11.2 MB | 11.1 MB
**TACR** | 59.2 MB | 65 s  | 12 s | 3 s | 50.6 MB | 50.4 MB
**ACE3** | 174 MB  | 150 s | 30 s  | 8.5 s | 137 MB  | 135 MB

### `rust_backend` ([`miniz_oxide`](https://crates.io/crates/miniz_oxide))

No noticeable difference compared to default `miniz`.