### PR TITLE
Fix crash when no arguments are provided

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -342,6 +342,12 @@ fn main() {
         .unwrap_or_else(|e| {
             let mut args = std::env::args().collect::<Vec<_>>();
             args.remove(0);
+
+            if args.len() == 0 {
+                // No arguments provided, show usage
+                e.exit();
+            }
+
             let utility = Utility::from_str(&args[0]);
             if utility.is_ok() {
                 utilities::run(&utility.unwrap(), &mut args).unwrap_or_print();


### PR DESCRIPTION
**When merged this pull request will:**
- Fix crash when no arguments are provided
```thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', /rustc/3c235d5600393dfe6c36eeed34042efad8d4f26e\src\libcore\slice\mod.rs:2686:10```