### PR TITLE
Always set current path as first include folder

### DIFF
--- a/src/build/mod.rs
+++ b/src/build/mod.rs
@@ -108,7 +108,7 @@ fn _build(p: &crate::project::Project, source: &PathBuf, target: &PathBuf, pbm: 
     let mut outf = File::create(target)?;
 
     let mut include = p.include.to_owned();
-    include.push(PathBuf::from("."));
+    include.insert(0, PathBuf::from("."));
 
     if let Err(ref error) = armake2::pbo::cmd_build(
         source.to_path_buf(),   // Source


### PR DESCRIPTION
**When merged this pull request will:**
- Try to find any config includes in the current directory before trying other paths in include folders