### PR TITLE
Exit with error if any addons fails to build

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -286,6 +286,9 @@ fn run_command(args: &Args) -> Result<(), Error> {
         if !args.flag_nowarn {
             armake2::error::print_warning_summary();
         }
+        if !result.failed.is_empty() {
+            return Err(error!("Building of at least one addon failed"));
+        }
         Ok(())
     } else if args.cmd_clean {
         check(false, args.flag_force).unwrap_or_print();


### PR DESCRIPTION
**When merged this pull request will:**
- Exit with non zero status code if any addons fails to build
