### PR TITLE
--opts & --compats

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -126,7 +126,7 @@ A list of addtional addons to build. HEMTT will look for these in the `./optiona
 `hemtt build --opts tracers`  
 `hemtt build --opts tracers patrticles`
 
-## --compat
+## --compats
 A list of compat addons to build. HEMTT will look for these in the `./comapts` folder. Using `--compats all` will build all compats in the `./compats` folder. All compats are built when no filtering is specified (`hemtt build`).
 
 `hemtt build --compats hearing`  

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,7 +127,7 @@ A list of addtional addons to build. HEMTT will look for these in the `./optiona
 `hemtt build --opts tracers patrticles`
 
 ## --compats
-A list of compat addons to build. HEMTT will look for these in the `./comapts` folder. Using `--compats all` will build all compats in the `./compats` folder. All compats are built when no filtering is specified (`hemtt build`).
+A list of compat addons to build. HEMTT will look for these in the `./compats` folder. Using `--compats all` will build all compats in the `./compats` folder. All compats are built when no filtering is specified (`hemtt build`).
 
 `hemtt build --compats hearing`  
 `hemtt build --compats hearing zeus`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,7 @@ Usage:
     hemtt <a href="/HEMTT/#/usage?id=init">init</a>
     hemtt <a href="/HEMTT/#/usage?id=create">create</a>
     hemtt <a href="/HEMTT/#/usage?id=addon">addon</a> &lt;name&gt;
-    hemtt <a href="/HEMTT/#/usage?id=build">build</a> [<a href="/HEMTT/#/usage?id=addons">&lt;addons&gt;</a>] [<a href="/HEMTT/#/usage?id=-release">--release</a>] [<a href="/HEMTT/#/usage?id=-force">-f</a>] [<a href="/HEMTT/#/usage?id=-nowarn">--nowarn</a>] [<a href="/HEMTT/#/usage?id=-opts">--opts</a>=&lt;addons&gt;] [<a href="/HEMTT/#/usage?id=-skip">--skip</a>=&lt;addons&gt;]
+    hemtt <a href="/HEMTT/#/usage?id=build">build</a> [<a href="/HEMTT/#/usage?id=addons">&lt;addons&gt;</a>] [<a href="/HEMTT/#/usage?id=-release">--release</a>] [<a href="/HEMTT/#/usage?id=-force">-f</a>] [<a href="/HEMTT/#/usage?id=-nowarn">--nowarn</a>] [<a href="/HEMTT/#/usage?id=-opts">--opts</a>=&lt;addons&gt;] [<a href="/HEMTT/#/usage?id=-compats">--compats</a>=&lt;addons&gt;]
     hemtt <a href="/HEMTT/#/usage?id=clean">clean</a> [--force]
     hemtt <a href="/HEMTT/#/usage?id=run">run</a> &lt;script&gt;
     hemtt <a href="/HEMTT/#/usage?id=utility">&lt;utility&gt;</a>
@@ -14,12 +14,15 @@ Usage:
     hemtt --version
 
 Options:
-    -f --force          Overwrite target files
-       --nowarn         Suppress armake2 warnings
-       --opts=&lt;addons&gt;  Comma seperated list of addtional compontents to build
-       --skip=&lt;addons&gt;  Comma seperated list of addons to skip building
-    -h --help           Show usage information and exit
-       --version        Show version number and exit
+        --ci               Run in CI mode
+        --debug            Turn debugging information on
+    -f, --force            Rebuild existing files
+        --force-release    Remove an existing release
+    -h, --help             Prints help information
+        --no-progress      No progress bars
+        --release          Build a release
+        --time             Time the execution
+    -V, --version          Prints version information
 </pre>
 <hr/>
 
@@ -73,7 +76,7 @@ Create a new addon folder. Requires a name to be used for the addon.
 Build the project into PBO files. HEMTT will only build the files that have changed.
 
 ## addons
-A comma seperated list of addon to build. HEMTT will build all addons in the `./addons` folder if no addons are specified. HEMTT will always build all addons when using `--release`.
+A list of addon to build. HEMTT will build all addons in the `./addons` folder if no addons are specified. HEMTT will always build all addons when using `--release`.
 
 **Build all**  
 `hemtt build`
@@ -117,17 +120,17 @@ would produce
 This example is from the [HEMTT Example Project](https://github.com/synixebrett/HEMTT-Example)
 
 ## --opts
-A comma seperated list of addtional addons to build. HEMTT will look for these in the `./optionals` folder. Using `--opts all` will build all addons in the `./optionals` folder.
+A list of addtional addons to build. HEMTT will look for these in the `./optionals` folder. Using `--opts all` will build all addons in the `./optionals` folder. All optionals are built when no filtering is specified (`hemtt build`).
 
 `hemtt build --opts all`  
 `hemtt build --opts tracers`  
-`hemtt build --opts tracers,patrticles`
+`hemtt build --opts tracers patrticles`
 
-## --skip
-A comma seperated list of additonal addons to skip building.
+## --compat
+A list of compat addons to build. HEMTT will look for these in the `./comapts` folder. Using `--compats all` will build all compats in the `./compats` folder. All compats are built when no filtering is specified (`hemtt build`).
 
-`hemtt build --skip hearing`  
-`hemtt build --skip hearing,zeus`
+`hemtt build --compats hearing`  
+`hemtt build --compats hearing zeus`
 
 <hr/>
 

--- a/src/addons/location.rs
+++ b/src/addons/location.rs
@@ -1,0 +1,33 @@
+use std::path::PathBuf;
+
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
+#[derive(Clone, Debug, EnumIter, PartialEq)]
+pub enum AddonLocation {
+    Addons,
+    Compats,
+    Optionals,
+}
+impl ToString for AddonLocation {
+    fn to_string(&self) -> String {
+        String::from(match self {
+            AddonLocation::Addons => "addons",
+            AddonLocation::Compats => "compats",
+            AddonLocation::Optionals => "optionals",
+        })
+    }
+}
+impl AddonLocation {
+    pub fn to_path_buf(&self) -> PathBuf {
+        PathBuf::from(self.to_string())
+    }
+
+    pub fn exists(&self) -> bool {
+        self.to_path_buf().exists()
+    }
+
+    pub fn all() -> Vec<AddonLocation> {
+        AddonLocation::iter().collect()
+    }
+}

--- a/src/addons/mod.rs
+++ b/src/addons/mod.rs
@@ -4,30 +4,10 @@ use std::path::PathBuf;
 use handlebars::to_json;
 use serde_json::value::Value as Json;
 
-use strum_macros::EnumIter;
-
 use crate::{HEMTTError, Project};
 
-#[derive(Clone, Debug, EnumIter, PartialEq)]
-pub enum AddonLocation {
-    Addons,
-    Compats,
-    Optionals,
-}
-impl ToString for AddonLocation {
-    fn to_string(&self) -> String {
-        String::from(match self {
-            AddonLocation::Addons => "addons",
-            AddonLocation::Compats => "compats",
-            AddonLocation::Optionals => "optionals",
-        })
-    }
-}
-impl AddonLocation {
-    pub fn to_path_buf(&self) -> PathBuf {
-        PathBuf::from(self.to_string())
-    }
-}
+mod location;
+pub use location::AddonLocation;
 
 #[derive(Debug)]
 pub struct Addon {

--- a/src/commands/build/checks/clear.rs
+++ b/src/commands/build/checks/clear.rs
@@ -10,10 +10,10 @@ use strum::IntoEnumIterator;
 
 use crate::{Addon, AddonList, AddonLocation, HEMTTError, Project, Report, Stage, Task};
 
-// Clears existing files that will be rebuilt only
+// Cleans existing files that will be rebuilt only
 #[derive(Clone)]
-pub struct Clear {}
-impl Task for Clear {
+pub struct Clean {}
+impl Task for Clean {
     fn can_run(&self, _: &Addon, _: &Report, _: &Project, _: &Stage) -> Result<bool, HEMTTError> {
         Ok(true)
     }
@@ -27,10 +27,10 @@ impl Task for Clear {
     }
 }
 
-// Cleans all pbo files
+// Clears all pbo files
 #[derive(Clone)]
-pub struct Clean {}
-impl Task for Clean {
+pub struct Clear {}
+impl Task for Clear {
     fn single(&self, addons: Vec<Result<(Report, Addon), HEMTTError>>, p: &Project, _: &Stage) -> AddonList {
         let re = Regex::new(r"(?m)(.+?)\.pbo$").unwrap();
         let mut targets = Vec::new();

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -1,13 +1,10 @@
-use std::path::Path;
-
-pub mod addon;
 #[allow(clippy::module_inception)]
 pub mod build;
 pub mod checks;
 pub mod postbuild;
 pub mod prebuild;
 
-use crate::{Addon, AddonLocation, Command, Flow, HEMTTError, Project, Stage, Step};
+use crate::{Command, Flow, HEMTTError, Project, Stage, Step};
 
 pub struct Build {}
 impl Command for Build {
@@ -15,44 +12,21 @@ impl Command for Build {
         clap::SubCommand::with_name("build")
             .version(*crate::VERSION)
             .about("Build the Project")
-            .arg(
-                clap::Arg::with_name("release")
-                    .help("Build a release")
-                    .long("release")
-                    .conflicts_with("dev"),
-            )
-            .arg(
-                clap::Arg::with_name("rebuild")
-                    .help("Rebuild existing files")
-                    .long("rebuild")
-                    .long("force")
-                    .short("f"),
-            )
-            .arg(
-                clap::Arg::with_name("force-release")
-                    .help("Remove an existing release")
-                    .long("force-release"),
-            )
+            .args(&super::building_args())
     }
 
     fn run(&self, args: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::build::get_addons(AddonLocation::Addons)?;
-        if Path::new(&AddonLocation::Optionals.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Optionals)?);
-        }
-        if Path::new(&AddonLocation::Compats.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Compats)?);
-        }
+        let mut addons = crate::project::addons::get_from_args(&args)?;
         let flow = Flow {
             steps: vec![
-                Step::single(
+                Step::parallel(
                     "♻️",
                     "Clean",
                     Stage::Check,
                     vec![Box::new(crate::build::checks::clear::Clean {})],
                 ),
-                if args.is_present("rebuild") {
-                    Step::parallel(
+                if args.is_present("force") {
+                    Step::single(
                         "🗑️",
                         "Clear",
                         Stage::Check,
@@ -119,15 +93,4 @@ impl Command for Build {
         flow.execute(addons, &mut p)?;
         Ok(())
     }
-}
-
-pub fn get_addons(location: AddonLocation) -> Result<Vec<Addon>, HEMTTError> {
-    Ok(std::fs::read_dir(&location.to_string())?
-        .map(|file| file.unwrap().path())
-        .filter(|file_or_dir| file_or_dir.is_dir())
-        .map(|file| Addon {
-            name: file.file_name().unwrap().to_str().unwrap().to_owned(),
-            location: location.clone(),
-        })
-        .collect())
 }

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -16,7 +16,7 @@ impl Command for Build {
     }
 
     fn run(&self, args: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::project::addons::get_from_args(&args)?;
+        let addons = crate::project::addons::get_from_args(&args)?;
         let flow = Flow {
             steps: vec![
                 Step::parallel(

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -9,7 +9,7 @@ impl Command for Clean {
     }
 
     fn run(&self, _: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::project::addons::get_all()?;
+        let addons = crate::project::addons::get_all()?;
         let flow = Flow {
             steps: vec![
                 Step::parallel(

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -12,13 +12,13 @@ impl Command for Clean {
         let mut addons = crate::project::addons::get_all()?;
         let flow = Flow {
             steps: vec![
-                Step::single(
+                Step::parallel(
                     "♻️",
                     "Clean",
                     Stage::Check,
                     vec![Box::new(crate::build::checks::clear::Clean {})],
                 ),
-                Step::parallel(
+                Step::single(
                     "🗑️",
                     "Clear",
                     Stage::Check,

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,6 +1,4 @@
-use std::path::Path;
-
-use crate::{AddonLocation, Command, Flow, HEMTTError, Project, Stage, Step};
+use crate::{Command, Flow, HEMTTError, Project, Stage, Step};
 
 pub struct Clean {}
 impl Command for Clean {
@@ -11,13 +9,7 @@ impl Command for Clean {
     }
 
     fn run(&self, _: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::build::get_addons(AddonLocation::Addons)?;
-        if Path::new(&AddonLocation::Optionals.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Optionals)?);
-        }
-        if Path::new(&AddonLocation::Compats.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Compats)?);
-        }
+        let mut addons = crate::project::addons::get_all()?;
         let flow = Flow {
             steps: vec![
                 Step::single(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -36,7 +36,7 @@ pub trait Command {
 }
 
 pub fn building_args<'a, 'b>() -> Vec<clap::Arg<'a, 'b>> {
-    vec!(
+    vec![
         clap::Arg::with_name("addons")
             .help("Addons to build")
             .takes_value(true)
@@ -69,5 +69,5 @@ pub fn building_args<'a, 'b>() -> Vec<clap::Arg<'a, 'b>> {
             .short("c")
             .takes_value(true)
             .multiple(true),
-    )
+    ]
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -34,3 +34,40 @@ pub trait Command {
         unimplemented!();
     }
 }
+
+pub fn building_args<'a, 'b>() -> Vec<clap::Arg<'a, 'b>> {
+    vec!(
+        clap::Arg::with_name("addons")
+            .help("Addons to build")
+            .takes_value(true)
+            .multiple(true)
+            .required(false),
+        clap::Arg::with_name("release")
+            .help("Build a release")
+            .long("release")
+            .conflicts_with("dev"),
+        clap::Arg::with_name("force")
+            .help("Rebuild existing files")
+            .long("force")
+            .short("f"),
+        clap::Arg::with_name("force-release")
+            .help("Remove an existing release")
+            .long("force-release"),
+        clap::Arg::with_name("skip")
+            .help("Skip addons")
+            .long("skip")
+            .takes_value(true),
+        clap::Arg::with_name("opts")
+            .help("Only build listed optional addons")
+            .long("opts")
+            .short("o")
+            .takes_value(true)
+            .multiple(true),
+        clap::Arg::with_name("compats")
+            .help("Only build listed compat addons")
+            .long("compats")
+            .short("c")
+            .takes_value(true)
+            .multiple(true),
+    )
+}

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -1,6 +1,4 @@
-use std::path::Path;
-
-use crate::{AddonLocation, Command, Flow, HEMTTError, Project, Stage, Step};
+use crate::{Command, Flow, HEMTTError, Project, Stage, Step};
 
 pub struct Pack {}
 impl Command for Pack {
@@ -8,34 +6,11 @@ impl Command for Pack {
         clap::SubCommand::with_name("pack")
             .version(*crate::VERSION)
             .about("Pack the Project")
-            .arg(
-                clap::Arg::with_name("release")
-                    .help("Pack a release")
-                    .long("release")
-                    .conflicts_with("dev"),
-            )
-            .arg(
-                clap::Arg::with_name("clear")
-                    .help("Clears existing built files")
-                    .long("clear")
-                    .long("force")
-                    .short("f"),
-            )
-            .arg(
-                clap::Arg::with_name("force-release")
-                    .help("Remove an existing release")
-                    .long("force-release"),
-            )
+            .args(&super::building_args())
     }
 
     fn run(&self, args: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::build::get_addons(AddonLocation::Addons)?;
-        if Path::new(&AddonLocation::Optionals.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Optionals)?);
-        }
-        if Path::new(&AddonLocation::Compats.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Compats)?);
-        }
+        let mut addons = crate::project::addons::get_from_args(&args)?;
         let flow = Flow {
             steps: vec![
                 Step::single(
@@ -44,7 +19,7 @@ impl Command for Pack {
                     Stage::Check,
                     vec![Box::new(crate::build::checks::clear::Clean {})],
                 ),
-                if args.is_present("clear") {
+                if args.is_present("force") {
                     Step::parallel(
                         "🗑️",
                         "Clear",

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -13,14 +13,14 @@ impl Command for Pack {
         let mut addons = crate::project::addons::get_from_args(&args)?;
         let flow = Flow {
             steps: vec![
-                Step::single(
+                Step::parallel(
                     "♻️",
                     "Clean",
                     Stage::Check,
                     vec![Box::new(crate::build::checks::clear::Clean {})],
                 ),
                 if args.is_present("force") {
-                    Step::parallel(
+                    Step::single(
                         "🗑️",
                         "Clear",
                         Stage::Check,

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -10,7 +10,7 @@ impl Command for Pack {
     }
 
     fn run(&self, args: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::project::addons::get_from_args(&args)?;
+        let addons = crate::project::addons::get_from_args(&args)?;
         let flow = Flow {
             steps: vec![
                 Step::parallel(

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,6 +1,4 @@
-use std::path::Path;
-
-use crate::{AddonLocation, Command, Flow, HEMTTError, Project, Stage, Step};
+use crate::{Command, Flow, HEMTTError, Project, Stage, Step};
 
 pub struct Status {}
 impl Command for Status {
@@ -10,14 +8,8 @@ impl Command for Status {
             .about("Get the status of your project")
     }
 
-    fn run(&self, _: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::build::get_addons(AddonLocation::Addons)?;
-        if Path::new(&AddonLocation::Optionals.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Optionals)?);
-        }
-        if Path::new(&AddonLocation::Compats.to_string()).exists() {
-            addons.extend(crate::build::get_addons(AddonLocation::Compats)?);
-        }
+    fn run(&self, args: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
+        let mut addons = crate::project::addons::get_all()?;
         let flow = Flow {
             steps: vec![Step::parallel(
                 "🔍",

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -8,8 +8,8 @@ impl Command for Status {
             .about("Get the status of your project")
     }
 
-    fn run(&self, args: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
-        let mut addons = crate::project::addons::get_all()?;
+    fn run(&self, _: &clap::ArgMatches, mut p: Project) -> Result<(), HEMTTError> {
+        let addons = crate::project::addons::get_all()?;
         let flow = Flow {
             steps: vec![Step::parallel(
                 "🔍",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use clap::App;
 #[macro_use]
 pub mod macros;
 
+pub mod addons;
 pub mod commands;
 pub mod error;
 pub mod files;
@@ -16,7 +17,7 @@ pub mod render;
 mod startup;
 pub mod utilities;
 
-pub use build::addon::{Addon, AddonLocation};
+pub use addons::{Addon, AddonLocation};
 pub use commands::{build, Command};
 pub use error::{FileErrorLineNumber, HEMTTError, IOPathError};
 pub use files::{FileCache, RenderedFiles};

--- a/src/project/addons.rs
+++ b/src/project/addons.rs
@@ -1,0 +1,66 @@
+use crate::{Addon, AddonLocation, HEMTTError};
+
+pub fn get_from_args(args: &clap::ArgMatches) -> Result<Vec<Addon>, HEMTTError> {
+    let all = args.value_of("addons").unwrap_or("") == "all";
+    let mut addons: Vec<Addon> = if args.is_present("addons") && !all {
+        get_from_location(&AddonLocation::Addons)?.into_iter().filter(|a| {
+            args.values_of("addons").unwrap().collect::<Vec<&str>>().contains(&a.name.as_str())
+        }).collect()
+    } else if all || (!args.is_present("opts") && !args.is_present("compats")) {
+        get_from_location(&AddonLocation::Addons)?
+    } else {
+        Vec::new()
+    };
+    if args.is_present("opts") {
+        println!("Opts: {:?}", args.values_of("opts"));
+        addons.extend(
+            if args.value_of("opts").unwrap_or("") == "all" {
+                get_from_location(&AddonLocation::Optionals)?
+            } else {
+                get_from_location(&AddonLocation::Optionals)?.into_iter().filter(|a| {
+                    args.values_of("opts").unwrap().collect::<Vec<&str>>().contains(&a.name.as_str())
+                }).collect()
+            }
+        );
+    }
+    if args.is_present("compats") {
+        addons.extend(
+            if args.value_of("compats").unwrap_or("") == "all" {
+                get_from_location(&AddonLocation::Compats)?
+            } else {
+                get_from_location(&AddonLocation::Compats)?.into_iter().filter(|a| {
+                    args.values_of("compats").unwrap().collect::<Vec<&str>>().contains(&a.name.as_str())
+                }).collect()
+            }
+        );
+    }
+    if !args.is_present("addons") && !args.is_present("opts") && !args.is_present("compats") {
+        addons.extend(get_from_locations(&[AddonLocation::Optionals, AddonLocation::Compats])?);
+    }
+    Ok(addons)
+}
+
+pub fn get_all() -> Result<Vec<Addon>, HEMTTError> {
+    get_from_locations(&AddonLocation::all())
+}
+
+pub fn get_from_locations(locations: &[AddonLocation]) -> Result<Vec<Addon>, HEMTTError> {
+    let mut addons = Vec::new();
+    for location in locations {
+        if location.exists() {
+            addons.extend(get_from_location(location)?);
+        }
+    }
+    Ok(addons)
+}
+
+pub fn get_from_location(location: &AddonLocation) -> Result<Vec<Addon>, HEMTTError> {
+    Ok(std::fs::read_dir(location.to_string())?
+        .map(|file| file.unwrap().path())
+        .filter(|file_or_dir| file_or_dir.is_dir())
+        .map(|file| Addon {
+            name: file.file_name().unwrap().to_str().unwrap().to_owned(),
+            location: location.clone(),
+        })
+        .collect())
+}

--- a/src/project/addons.rs
+++ b/src/project/addons.rs
@@ -3,9 +3,10 @@ use crate::{Addon, AddonLocation, HEMTTError};
 pub fn get_from_args(args: &clap::ArgMatches) -> Result<Vec<Addon>, HEMTTError> {
     let all = args.value_of("addons").unwrap_or("") == "all";
     let mut addons: Vec<Addon> = if args.is_present("addons") && !all {
-        get_from_location(&AddonLocation::Addons)?.into_iter().filter(|a| {
-            args.values_of("addons").unwrap().collect::<Vec<&str>>().contains(&a.name.as_str())
-        }).collect()
+        get_from_location(&AddonLocation::Addons)?
+            .into_iter()
+            .filter(|a| args.values_of("addons").unwrap().any(|x| x == a.name.as_str()))
+            .collect()
     } else if all || (!args.is_present("opts") && !args.is_present("compats")) {
         get_from_location(&AddonLocation::Addons)?
     } else {
@@ -13,26 +14,24 @@ pub fn get_from_args(args: &clap::ArgMatches) -> Result<Vec<Addon>, HEMTTError> 
     };
     if args.is_present("opts") {
         println!("Opts: {:?}", args.values_of("opts"));
-        addons.extend(
-            if args.value_of("opts").unwrap_or("") == "all" {
-                get_from_location(&AddonLocation::Optionals)?
-            } else {
-                get_from_location(&AddonLocation::Optionals)?.into_iter().filter(|a| {
-                    args.values_of("opts").unwrap().collect::<Vec<&str>>().contains(&a.name.as_str())
-                }).collect()
-            }
-        );
+        addons.extend(if args.value_of("opts").unwrap_or("") == "all" {
+            get_from_location(&AddonLocation::Optionals)?
+        } else {
+            get_from_location(&AddonLocation::Optionals)?
+                .into_iter()
+                .filter(|a| args.values_of("opts").unwrap().any(|x| x == a.name.as_str()))
+                .collect()
+        });
     }
     if args.is_present("compats") {
-        addons.extend(
-            if args.value_of("compats").unwrap_or("") == "all" {
-                get_from_location(&AddonLocation::Compats)?
-            } else {
-                get_from_location(&AddonLocation::Compats)?.into_iter().filter(|a| {
-                    args.values_of("compats").unwrap().collect::<Vec<&str>>().contains(&a.name.as_str())
-                }).collect()
-            }
-        );
+        addons.extend(if args.value_of("compats").unwrap_or("") == "all" {
+            get_from_location(&AddonLocation::Compats)?
+        } else {
+            get_from_location(&AddonLocation::Compats)?
+                .into_iter()
+                .filter(|a| args.values_of("compats").unwrap().any(|x| x == a.name.as_str()))
+                .collect()
+        });
     }
     if !args.is_present("addons") && !args.is_present("opts") && !args.is_present("compats") {
         addons.extend(get_from_locations(&[AddonLocation::Optionals, AddonLocation::Compats])?);

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -10,6 +10,7 @@ use serde_json::value::Value as Json;
 use crate::error::PrintableError;
 use crate::HEMTTError;
 
+pub mod addons;
 pub mod semver;
 mod signing;
 


### PR DESCRIPTION
**When merged this pull request will:**
- Add ability to specify addons to build

Examples
```
hemtt build
addons/*, optionals/*, compats/*

hemtt build all
addons/*

hemtt build zeus music
addons/zeus, addons/music


hemtt build --opts maps
optionals/maps

hemtt build zeus --opts maps music
addons/zeus, optionals/maps, optionals/music

hemtt build all --opts maps
addons/*, optionals/maps


hemtt build --compats maps
compats/maps

hemtt build all --compats maps
addons/*, compats/maps

hemtt build all --opts music zues --compats maps
Builds addons/*, optionals/music, optionals/zeus, compats/maps

hemtt build all --opts all --compats maps
addons/*, optionals/*, compats/maps
```