### PR TITLE
Fix Installer Folder Struture 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ artifacts:
 
 before_deploy:
   - cargo rustc --target %TARGET% --release --bin hemtt -- -C lto
-  - call "C:\\Program Files (x86)\\Inno Setup 6\\iscc.exe" ci\wininstaller.iss
+  - call "C:\\Program Files (x86)\\Inno Setup 5\\iscc.exe" ci\wininstaller.iss
   - ps: ci\before_deploy.ps1
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ artifacts:
 
 before_deploy:
   - cargo rustc --target %TARGET% --release --bin hemtt -- -C lto
-  - call "C:\\Program Files (x86)\\Inno Setup 5\\iscc.exe" ci\wininstaller.iss
+  - call "C:\\Program Files (x86)\\Inno Setup 6\\iscc.exe" ci\wininstaller.iss
   - ps: ci\before_deploy.ps1
 
 deploy:

--- a/ci/wininstaller.iss
+++ b/ci/wininstaller.iss
@@ -11,7 +11,7 @@ AppVersion=stable
 AppPublisherURL=https://github.com/SynixeBrett/HEMTT
 AppSupportURL=https://github.com/SynixeBrett/HEMTT
 AppUpdatesURL=https://github.com/SynixeBrett/HEMTT
-DefaultDirName={commonpf}\HEMTT
+DefaultDirName={pf}\HEMTT
 DefaultGroupName=HEMTT
 DisableProgramGroupPage=yes
 LicenseFile=..\LICENSE
@@ -30,7 +30,7 @@ Source: "..\target\{#target}\release\hemtt.exe"; DestDir: "{app}\bin"; Flags: ig
 Name: "{group}\HEMTT"; Filename: "{app}\bin\hemtt.exe"
 
 [Registry]
-Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{commonpf}\HEMTT\bin"; Check: NeedsAddPath('{commonpf}\HEMTT\bin')
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{pf}\HEMTT\bin"; Check: NeedsAddPath('{pf}\HEMTT\bin')
 
 [Code]
 

--- a/ci/wininstaller.iss
+++ b/ci/wininstaller.iss
@@ -11,7 +11,7 @@ AppVersion=stable
 AppPublisherURL=https://github.com/SynixeBrett/HEMTT
 AppSupportURL=https://github.com/SynixeBrett/HEMTT
 AppUpdatesURL=https://github.com/SynixeBrett/HEMTT
-DefaultDirName={pf}\HEMTT
+DefaultDirName={commonpf}\HEMTT
 DefaultGroupName=HEMTT
 DisableProgramGroupPage=yes
 LicenseFile=..\LICENSE
@@ -23,14 +23,14 @@ SolidCompression=yes
 Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Files]
-Source: "..\target\{#target}\release\hemtt.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\target\{#target}\release\hemtt.exe"; DestDir: "{app}\bin"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Icons]
-Name: "{group}\HEMTT"; Filename: "{app}\hemtt.exe"
+Name: "{group}\HEMTT"; Filename: "{app}\bin\hemtt.exe"
 
 [Registry]
-Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{pf}\HEMTT"; Check: NeedsAddPath('{pf}\HEMTT')
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{commonpf}\HEMTT\bin"; Check: NeedsAddPath('{commonpf}\HEMTT\bin')
 
 [Code]
 


### PR DESCRIPTION
**When merged this pull request will:**
Move Hemtt.exe to subfolder when installed via the setup to remove uninst00.exe/dat from command line
