### PR TITLE
Support directories in files configuration

### DIFF
--- a/docs/project.md
+++ b/docs/project.md
@@ -98,7 +98,7 @@ files = [
 ]
 ```
 - Can specify a file or a directory.
-- Directory can end with `/` to mirror the while structure. Otherwise it will be placed in root of release folder.
+- Directory can end with `/` to mirror the whole structure. Otherwise it will be placed in root of release folder.
 <hr/>
 
 ## include

--- a/docs/project.md
+++ b/docs/project.md
@@ -86,15 +86,19 @@ If you are using `addons/main/script_version.hpp` the file must be formatted as:
 ## files
 **Type**: Array \[String\]
 
-HEMTT will copy the files to the release directory after a successful release build. Supports [glob](http://man7.org/linux/man-pages/man7/glob.7.html) patterns.
+HEMTT will copy the files and directories to the release directory after a successful release build. Supports [glob](http://man7.org/linux/man-pages/man7/glob.7.html) patterns.
 
 ```toml
 files = [
     "mod.cpp",
     "logo.paa",
-    "*.dll"
+    "*.dll",
+    "extras/plugin",  # directory copied as '@mod/plugin'
+    "template/userconfig/"  # directory copied as '@mod/template/userconfig'
 ]
 ```
+- Can specify a file or a directory.
+- Directory can end with `/` to mirror the while structure. Otherwise it will be placed in root of release folder.
 <hr/>
 
 ## include

--- a/src/commands/build/postbuild/release.rs
+++ b/src/commands/build/postbuild/release.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use dialoguer::Confirmation;
 use glob::glob;
 
@@ -52,12 +54,16 @@ impl Task for Release {
         for file in &p.files {
             for entry in glob(file)? {
                 if let Ok(path) = entry {
-                    copy_file!(path, {
-                        let mut d = release_folder.clone();
+                    let mut d = release_folder.clone();
+
+                    if fs::metadata(&path).unwrap().is_dir() {
+                        debug!("Copying dir {:#?} to {:#?}", path, d);
+                        copy_dir!(path, d)?;
+                    } else {
                         d.push(path.file_name().unwrap().to_str().unwrap().to_owned());
-                        debug!("Copying {:#?} to {:#?}", path, d);
-                        d
-                    })?;
+                        debug!("Copying file {:#?} to {:#?}", path, d);
+                        copy_file!(path, d)?;
+                    }
                 }
             }
         }

--- a/src/commands/build/postbuild/release.rs
+++ b/src/commands/build/postbuild/release.rs
@@ -57,6 +57,11 @@ impl Task for Release {
                     let mut d = release_folder.clone();
 
                     if fs::metadata(&path).unwrap().is_dir() {
+                        if file.ends_with("/") {
+                            // Mirror directory structure if path ends in slash
+                            d.push(path.parent().unwrap());
+                            create_dir!(d)?;
+                        }
                         debug!("Copying dir {:#?} to {:#?}", path, d);
                         copy_dir!(path, d)?;
                     } else {

--- a/src/commands/build/postbuild/release.rs
+++ b/src/commands/build/postbuild/release.rs
@@ -57,7 +57,7 @@ impl Task for Release {
                     let mut d = release_folder.clone();
 
                     if fs::metadata(&path).unwrap().is_dir() {
-                        if file.ends_with("/") {
+                        if file.ends_with('/') {
                             // Mirror directory structure if path ends in slash
                             d.push(path.parent().unwrap());
                             create_dir!(d)?;

--- a/src/macros/fs.rs
+++ b/src/macros/fs.rs
@@ -39,7 +39,7 @@ macro_rules! copy_file {
     ($s:expr, $d:expr) => {
         std::fs::copy(&$s, &$d).map_err(|source| {
             crate::HEMTTError::GENERIC(
-                format!("Unable to copy: {}", source),
+                format!("Unable to copy file: {}", source),
                 format!("`{:#?}` => `{:#?}`", $s, $d),
             )
         })
@@ -47,11 +47,24 @@ macro_rules! copy_file {
 }
 
 #[macro_export]
+macro_rules! copy_dir {
+    ($s:expr, $d:expr) => {
+        fs_extra::dir::copy(&$s, &$d, &fs_extra::dir::CopyOptions::new()).map_err(|source| {
+            crate::HEMTTError::GENERIC(
+                format!("Unable to copy directory: {}", source),
+                format!("`{:#?}` => `{:#?}`", $s, $d),
+            )
+        })
+    };
+}
+
+
+#[macro_export]
 macro_rules! rename_file {
     ($s:expr, $d:expr) => {
         std::fs::rename(&$s, &$d).map_err(|source| {
             crate::HEMTTError::GENERIC(
-                format!("Unable to rename: {}", source),
+                format!("Unable to rename file: {}", source),
                 format!("`{:#?}` => `{:#?}`", $s, $d),
             )
         })

--- a/src/macros/fs.rs
+++ b/src/macros/fs.rs
@@ -58,7 +58,6 @@ macro_rules! copy_dir {
     };
 }
 
-
 #[macro_export]
 macro_rules! rename_file {
     ($s:expr, $d:expr) => {


### PR DESCRIPTION
**When merged this pull request will:**
- Finish all set goals of #88
- Support copying directories specified in `files` in 2 ways:
  - Specified folder into root of release folder
    - Example: `"extras/plugin` -> `releases/<version>/@<mod>/plugin`
  - Specified folder with mirrored structure (`/` at the end)
    - Example: `"extras/plugin/` -> `releases/<version>/@<mod>/extras/plugin`