### PR TITLE
Support running build steps in release-only or development-only

### DIFF
--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -31,9 +31,19 @@ steps = [
 show_output = true
 ```
 
+### only_development / only_release
+Scripts run during normal and release builds. Setting `only_release` will run the script only in release build and setting `only_development` will run the script only in development build.
+```toml
+[scripts.example]
+steps = [
+    "echo 'this is an example'"
+]
+only_release = true
+```
+
 
 # Build Steps
-There are 3 different build step definitions. `prebuild`, `postbuild` and `releasebuild`. These are added to the root of the HEMTT project file. Scripts can be ran using `![script]` and utilities are ran using `@[utility]`. The following example runs the `build` script, the uses `cp` to copy files.
+There are 4 different build step definitions. `check`, `prebuild`, `postbuild` and `releasebuild`. These are added to the root of the HEMTT project file. Scripts can be ran using `![script]` and utilities are ran using `@[utility]`. The following example runs the `build` script, the uses `cp` to copy files.
 ```toml
 releasebuild = [
   "!build"
@@ -51,16 +61,16 @@ steps_windows = [
 ```
 
 ### foreach
-Scripts can be ran for each addons. Inside `prebuild` the script will be ran for each addon that HEMTT will build, including addons that will be skipped if they are already built. Inside `postbuild` and `releasebuild` only addons that were successfully built with be used, excluding addons that were skipped for being up to date.
+Scripts can be ran for each addons. Inside `check` and `prebuild` the script will be ran for each addon that HEMTT will build, including addons that will be skipped if they are already built. Inside `postbuild` and `releasebuild` only addons that were successfully built with be used, excluding addons that were skipped for being up to date.
 
 In addition to the standard [templating variables](templating.md), additional variables are added when using foreach.
 
-| Variable | prebuild            | postbuild           | releasebuild        |
-|----------|---------------------|---------------------|---------------------|
-| addon    | main                | main                | main                |
-| source   | addons/main         | addons/main         | addons/main         |
-| target   | addons/ABE_main.pbo | addons/ABE_main.pbo | addons/ABE_main.pbo |
-| time     |                     | (build time in ms)  | (build time in ms)  |
+| Variable | check & prebuild    | postbuild & releasebuild |
+|----------|---------------------|--------------------------|
+| addon    | main                | main                     |
+| source   | addons/main         | addons/main              |
+| target   | addons/ABE_main.pbo | addons/ABE_main.pbo      |
+| time     |                     | (build time in ms)       |
 
 ```toml
 postbuild = [

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -46,21 +46,42 @@ impl Command for Build {
                         Box::new(crate::build::checks::modtime::ModTime {}),
                     ],
                 ),
-                Step::single("📜", "", Stage::Check, vec![Box::new(crate::flow::Script {})]),
+                Step::single(
+                    "📜",
+                    "",
+                    Stage::Check,
+                    vec![Box::new(crate::flow::Script {
+                        release: args.is_present("release"),
+                    })],
+                ),
                 Step::parallel(
                     "🚧",
                     "Prebuild",
                     Stage::PreBuild,
                     vec![Box::new(crate::build::prebuild::preprocess::Preprocess {})],
                 ),
-                Step::single("📜", "", Stage::PreBuild, vec![Box::new(crate::flow::Script {})]),
+                Step::single(
+                    "📜",
+                    "",
+                    Stage::PreBuild,
+                    vec![Box::new(crate::flow::Script {
+                        release: args.is_present("release"),
+                    })],
+                ),
                 Step::parallel(
                     "📝",
                     "Build",
                     Stage::Build,
                     vec![Box::new(crate::build::build::Build::new(true))],
                 ),
-                Step::single("📜", "", Stage::PostBuild, vec![Box::new(crate::flow::Script {})]),
+                Step::single(
+                    "📜",
+                    "",
+                    Stage::PostBuild,
+                    vec![Box::new(crate::flow::Script {
+                        release: args.is_present("release"),
+                    })],
+                ),
                 if args.is_present("release") {
                     Step::single(
                         "⭐",
@@ -84,7 +105,13 @@ impl Command for Build {
                     Step::none()
                 },
                 if args.is_present("release") {
-                    Step::single("📜", "", Stage::ReleaseBuild, vec![Box::new(crate::flow::Script {})])
+                    Step::single("📜",
+                        "",
+                        Stage::ReleaseBuild,
+                        vec![Box::new(crate::flow::Script {
+                            release: args.is_present("release"),
+                        })],
+                    )
                 } else {
                     Step::none()
                 },

--- a/src/commands/build/mod.rs
+++ b/src/commands/build/mod.rs
@@ -105,7 +105,8 @@ impl Command for Build {
                     Step::none()
                 },
                 if args.is_present("release") {
-                    Step::single("📜",
+                    Step::single(
+                        "📜",
                         "",
                         Stage::ReleaseBuild,
                         vec![Box::new(crate::flow::Script {

--- a/src/commands/pack.rs
+++ b/src/commands/pack.rs
@@ -59,7 +59,14 @@ impl Command for Pack {
                     Step::none()
                 },
                 if args.is_present("release") {
-                    Step::single("📜", "", Stage::ReleaseBuild, vec![Box::new(crate::flow::Script {})])
+                    Step::single(
+                        "📜",
+                        "",
+                        Stage::ReleaseBuild,
+                        vec![Box::new(crate::flow::Script {
+                            release: args.is_present("release"),
+                        })],
+                    )
                 } else {
                     Step::none()
                 },

--- a/src/flow/script/mod.rs
+++ b/src/flow/script/mod.rs
@@ -5,8 +5,11 @@ pub use task::Script;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BuildScript {
-    #[serde(default = "default_release")]
-    pub release: bool,
+    #[serde(default = "default_only_development")]
+    pub only_development: bool,
+
+    #[serde(default = "default_only_release")]
+    pub only_release: bool,
 
     #[serde(default = "default_foreach")]
     pub foreach: bool,
@@ -29,9 +32,20 @@ pub struct BuildScript {
     #[serde(default = "Vec::new")]
     pub steps_linux: Vec<String>,
 }
+impl BuildScript {
+    pub fn should_run(&self, release: bool) -> bool {
+        (!self.only_development && !self.only_release) ||
+            (self.only_development && !release) ||
+            (self.only_release && release)
+    }
+}
 
-fn default_release() -> bool {
-    true
+fn default_only_development() -> bool {
+    false
+}
+
+fn default_only_release() -> bool {
+    false
 }
 
 fn default_foreach() -> bool {

--- a/src/flow/script/mod.rs
+++ b/src/flow/script/mod.rs
@@ -34,9 +34,9 @@ pub struct BuildScript {
 }
 impl BuildScript {
     pub fn should_run(&self, release: bool) -> bool {
-        (!self.only_development && !self.only_release) ||
-            (self.only_development && !release) ||
-            (self.only_release && release)
+        (!self.only_development && !self.only_release)
+            || (self.only_development && !release)
+            || (self.only_release && release)
     }
 }
 

--- a/src/flow/script/task.rs
+++ b/src/flow/script/task.rs
@@ -61,9 +61,12 @@ impl Script {
                             for step in steps {
                                 let exec = |data: &Result<(Report, Addon), HEMTTError>| {
                                     if let Ok((_, addon)) = data {
-                                        let step =
-                                            crate::render::run(step, Some(&format!("script:{}", &cmd)), &addon.get_variables(p))
-                                                .unwrap_or_print();
+                                        let step = crate::render::run(
+                                            step,
+                                            Some(&format!("script:{}", &cmd)),
+                                            &addon.get_variables(p),
+                                        )
+                                        .unwrap_or_print();
                                         Script::execute(&step, script.show_output, addons, p, s, release).unwrap_or_print();
                                     }
                                 };

--- a/src/flow/script/task.rs
+++ b/src/flow/script/task.rs
@@ -7,14 +7,16 @@ use crate::error::*;
 use crate::{Addon, AddonList, HEMTTError, Project, Report, Stage, Task};
 
 #[derive(Clone)]
-pub struct Script {}
+pub struct Script {
+    pub release: bool,
+}
 impl Task for Script {
     fn single(&self, addons: Vec<Result<(Report, Addon), HEMTTError>>, p: &Project, s: &Stage) -> AddonList {
         let steps = Script::get_scripts(s, p)?;
 
         for step in steps {
             println!("{} `{}`", s.to_string().blue().bold(), p.render(&step, None)?);
-            Script::execute(&step, false, &addons, p, s)?;
+            Script::execute(&step, false, &addons, p, s, self.release)?;
         }
 
         Ok(addons)
@@ -28,6 +30,7 @@ impl Script {
         addons: &[Result<(Report, Addon), HEMTTError>],
         p: &Project,
         s: &Stage,
+        release: bool,
     ) -> Result<(), HEMTTError> {
         let mut cmd = command.to_owned();
         match cmd.remove(0) {
@@ -53,27 +56,31 @@ impl Script {
                     } else {
                         &script.steps
                     };
-                    if script.foreach {
-                        for step in steps {
-                            let exec = |data: &Result<(Report, Addon), HEMTTError>| {
-                                if let Ok((_, addon)) = data {
-                                    let step =
-                                        crate::render::run(step, Some(&format!("script:{}", &cmd)), &addon.get_variables(p))
-                                            .unwrap_or_print();
-                                    Script::execute(&step, script.show_output, addons, p, s).unwrap_or_print();
+                    if script.should_run(release) {
+                        if script.foreach {
+                            for step in steps {
+                                let exec = |data: &Result<(Report, Addon), HEMTTError>| {
+                                    if let Ok((_, addon)) = data {
+                                        let step =
+                                            crate::render::run(step, Some(&format!("script:{}", &cmd)), &addon.get_variables(p))
+                                                .unwrap_or_print();
+                                        Script::execute(&step, script.show_output, addons, p, s, release).unwrap_or_print();
+                                    }
+                                };
+                                if script.parallel {
+                                    addons.par_iter().for_each(exec);
+                                } else {
+                                    addons.iter().for_each(exec);
                                 }
-                            };
-                            if script.parallel {
-                                addons.par_iter().for_each(exec);
-                            } else {
-                                addons.iter().for_each(exec);
+                            }
+                        } else {
+                            for step in steps {
+                                let step = crate::render::run(step, Some(&format!("script:{}", &cmd)), &p.get_variables())?;
+                                Script::execute(&step, script.show_output, addons, p, s, release)?;
                             }
                         }
                     } else {
-                        for step in steps {
-                            let step = crate::render::run(step, Some(&format!("script:{}", &cmd)), &p.get_variables())?;
-                            Script::execute(&step, script.show_output, addons, p, s)?;
-                        }
+                        println!("Script `{}` skipped", &cmd);
                     }
                 } else {
                     error!("Script `{}` does not exist", &cmd);


### PR DESCRIPTION
**When merged this pull request will:**
- Allow setting build scripts to only run during release build or only during development build (use: versioning). - close #297 
- Update Scripts documentation (partially).
  - Add `check` build step.
  - Compact table.

Made use of existing but unused `release` property.

Implementation could probably be nicer, mostly how to pass information on build type to the script. Feedback is welcome.