### PR TITLE
Support file directory mirror in files configuration

### DIFF
--- a/src/commands/build/postbuild/release.rs
+++ b/src/commands/build/postbuild/release.rs
@@ -52,11 +52,13 @@ impl Task for Release {
         }
 
         for mut file in p.files.to_owned() {
-            let mut mirror_structure = false;
-            if file.ends_with('/') {
+            // Mirror directory structure if path ends in slash
+            let mirror_structure = if file.ends_with('/') {
                 file.pop();
-                mirror_structure = true; // Mirror directory structure if path ends in slash
-            }
+                true
+            } else {
+                false
+            };
 
             for entry in glob(&file)? {
                 if let Ok(path) = entry {

--- a/src/commands/build/postbuild/release.rs
+++ b/src/commands/build/postbuild/release.rs
@@ -53,11 +53,9 @@ impl Task for Release {
 
         for mut file in p.files.to_owned() {
             // Mirror directory structure if path ends in slash
-            let mirror_structure = if file.ends_with('/') {
+            let mirror_structure = file.ends_with('/');
+            if mirror_structure {
                 file.pop();
-                true
-            } else {
-                false
             };
 
             for entry in glob(&file)? {


### PR DESCRIPTION
**When merged this pull request will:**
- Expand #295 for files (not just directories)
- Allow specifying file configuration as such:
  - Specified file into root of release folder
    - Example: `"extras/test.txt` -> `releases/<version>/@<mod>/test.txt`
  - Specified file with mirrored directory structure (`/` at the end)
    - Example: `"extras/test.txt/` -> `releases/<version>/@<mod>/extras/test.txt`

Required for ACRE2.