### PR TITLE
Udpate OpenSSL to 1.1.1e in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Install OpenSSL
         run: |
-          powershell -command "Invoke-WebRequest -Uri 'http://slproweb.com/download/Win64OpenSSL-1_1_1d.msi' -OutFile openssl.msi"
+          powershell -command "Invoke-WebRequest -Uri 'http://slproweb.com/download/Win64OpenSSL-1_1_1e.msi' -OutFile openssl.msi"
           msiexec.exe /qn /i openssl.msi
 
       - name: Build


### PR DESCRIPTION
**When merged this pull request will:**
- Title

OpenSSL was just updated to 1.1.1e today. URL to 1.1.1d is no longer available as https://github.com/synixebrett/HEMTT/runs/516625275?check_suite_focus=true#step:4:13 shows.